### PR TITLE
chore: block deploy with uncommitted changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,12 @@ install: release
 DEPLOY_TARGET ?= $(HOME)/.local/share/muzzle
 
 deploy: release
+	@if [ -n "$$(git status --porcelain -- src/ Cargo.toml Cargo.lock Makefile)" ]; then \
+		echo "ERROR: Uncommitted changes in tracked build files."; \
+		echo "Commit or stash before deploying."; \
+		git status --short -- src/ Cargo.toml Cargo.lock Makefile; \
+		exit 1; \
+	fi
 	@echo "Deploying to $(DEPLOY_TARGET)/"
 	@mkdir -p $(DEPLOY_TARGET)/bin $(DEPLOY_TARGET)/src
 	@# Binaries


### PR DESCRIPTION
## Summary
- `make deploy` now fails if there are uncommitted changes in build-relevant files
- Prevents deploying hooks that aren't tracked in git (which caused the stdout contamination fixes to sit uncommitted)

## Test plan
- [x] Clean tree: `make deploy` succeeds
- [x] Dirty tree: `make deploy` errors with file list