### PR TITLE
fix(ci): use commit SHA for scorecard-action

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -27,11 +27,12 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
+      - uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
       - uses: github/codeql-action/upload-sarif@f35333b910470a5408cb081b68f0701254a7d27b # v3.28.18
+        if: always()
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary
- Pin `ossf/scorecard-action` to commit SHA `4eaacf0` instead of tag object SHA `99c09fe` — fixes "imposter commit" rejection from scorecard webapp
- Add `if: always()` to `upload-sarif` step so Code Scanning results upload even when `publish_results` fails
- Repo setting "Allow GitHub Actions to create PRs" enabled via API (fixes release-please failure)

## Root Cause
`v2.4.3` is an annotated tag. `git/ref/tags/v2.4.3` returns the tag object SHA (`99c09fe`), not the commit (`4eaacf0`). The scorecard webapp's workflow verification only recognizes commit SHAs.

## Test plan
- [ ] CI passes on this PR
- [ ] After merge: re-run OpenSSF Scorecard workflow — verify `publish_results` succeeds
- [ ] After merge: verify release-please creates a release PR