### PR TITLE
fix(ci): remove broken GITHUB_TOKEN close+reopen from release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,14 +26,7 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-      # GITHUB_TOKEN PRs don't trigger CI workflows (by design).
-      # Close+reopen the PR to trigger required status checks.
-      - name: Trigger CI on release PR
-        if: steps.release.outputs.pr
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ fromJSON(steps.release.outputs.pr).number }}
-          GH_REPO: ${{ github.repository }}
-        run: |
-          gh pr close "${PR_NUMBER}" --repo "${GH_REPO}" || true
-          gh pr reopen "${PR_NUMBER}" --repo "${GH_REPO}"
+      # NOTE: GITHUB_TOKEN events don't trigger other workflows.
+      # The close+reopen trick only works with a PAT or GitHub App token.
+      # To trigger CI on a release-please PR, manually close+reopen it:
+      #   gh pr close <N> --repo frits-v/muzzle && gh pr reopen <N> --repo frits-v/muzzle

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,8 @@
     ".": {
       "release-type": "rust",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "bump-patch-for-minor-pre-major": true,
+      "last-release-sha": "e1033cc154eb49de7ffeff1935467872fbe2bdc7"
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
## Summary

- Remove the close+reopen step from `release-please.yml` that used `github.token` (GITHUB_TOKEN) to trigger CI on release PRs — GITHUB_TOKEN events [don't trigger other workflows](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) by design, so the step was silently ineffective
- Replace with a comment documenting the manual workaround (close+reopen via PAT-backed `gh` CLI)
- Add `last-release-sha` to `release-please-config.json` pointing to `e1033cc` (PR #4 squash-merge — first main commit with `version = "0.2.0"`). The `muzzle-v0.2.0` tag is on a feature branch commit that's not an ancestor of `main`, causing release-please to walk the full history and produce duplicate changelog entries in PR #15.

## Test plan

- [x] CI passes on this PR (workflow lint validates the YAML)
- [ ] After merge, release-please regenerates PR #15 with correct changelog (only entries since e1033cc)
- [ ] PR #15 CI can be triggered via manual `gh pr close && gh pr reopen`