### PR TITLE
feat: opt-in jujutsu (jj) backend for workspace isolation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,10 @@ src/
   changelog.rs        # Audit log formatting + read-only detection
   log.rs              # Structured JSON logging to stderr
   mcp.rs              # MCP tool routing (GitHub, Atlassian, Datadog, etc.)
+  vcs/
+    mod.rs            # VcsBackend trait, VcsKind enum, auto-detection
+    git.rs            # GitBackend — delegates to worktree/ + gitcheck
+    jj.rs             # JjBackend — jj workspace ops + safety checks
   worktree/
     mod.rs            # Worktree creation, restore, ensure_for_repo
     git.rs            # Git command helpers (fetch, branch resolution)

--- a/hooks/src/bin/ensure_worktree.rs
+++ b/hooks/src/bin/ensure_worktree.rs
@@ -12,6 +12,7 @@
 
 use muzzle::config;
 use muzzle::session;
+use muzzle::vcs::VcsKind;
 use muzzle::worktree;
 
 fn main() {
@@ -27,12 +28,18 @@ fn main() {
 
 fn run() {
     let args: Vec<String> = std::env::args().collect();
-    if args.len() != 2 || args[1].is_empty() {
-        muzzle::log::error("ensure-worktree", "Usage: ensure-worktree <repo-name>");
+    if args.len() < 2 || args[1].is_empty() {
+        muzzle::log::error(
+            "ensure-worktree",
+            "Usage: ensure-worktree <repo-name> [vcs-kind]",
+        );
         std::process::exit(1);
     }
 
     let repo = &args[1];
+
+    // Parse optional VCS kind from second argument (default: Git)
+    let vcs_kind: VcsKind = args.get(2).and_then(|s| s.parse().ok()).unwrap_or_default();
 
     // Validate all workspaces exist before attempting anything
     if let Err(msg) = config::validate_workspaces() {
@@ -65,19 +72,48 @@ fn run() {
         }
     }
 
-    // Create worktree
-    let entry = match worktree::ensure_for_repo(&sess, repo) {
-        Ok(entry) => entry,
-        Err(e) => {
-            muzzle::log::emit_full(
-                "ERROR",
-                "ensure-worktree",
-                &format!("failed to create worktree for {}", repo),
-                None,
-                Some(&e.to_string()),
-            );
-            std::process::exit(1);
+    // Create worktree — route through appropriate VCS backend
+    let entry = match vcs_kind {
+        VcsKind::Jj | VcsKind::JjColocated => {
+            use muzzle::vcs::jj::JjBackend;
+            use muzzle::vcs::VcsBackend;
+            let jj = JjBackend {
+                colocated: vcs_kind == VcsKind::JjColocated,
+            };
+            // Resolve repo path
+            let repo_path = match config::workspaces()
+                .iter()
+                .map(|ws| ws.join(repo))
+                .find(|p| p.is_dir())
+            {
+                Some(p) => p,
+                None => {
+                    muzzle::log::error("ensure-worktree", &format!("repo not found: {repo}"));
+                    std::process::exit(1);
+                }
+            };
+            let dest = config::worktree_path(&repo_path, &sess.short_id);
+            match jj.workspace_add(&repo_path, &dest, &sess.short_id, None, &sess.tmp_dir) {
+                Ok(entry) => entry,
+                Err(e) => {
+                    muzzle::log::error("ensure-worktree", &format!("jj workspace add failed: {e}"));
+                    std::process::exit(1);
+                }
+            }
         }
+        VcsKind::Git => match worktree::ensure_for_repo(&sess, repo) {
+            Ok(entry) => entry,
+            Err(e) => {
+                muzzle::log::emit_full(
+                    "ERROR",
+                    "ensure-worktree",
+                    &format!("failed to create worktree for {}", repo),
+                    None,
+                    Some(&e.to_string()),
+                );
+                std::process::exit(1);
+            }
+        },
     };
 
     // Update spec file

--- a/hooks/src/bin/ensure_worktree.rs
+++ b/hooks/src/bin/ensure_worktree.rs
@@ -38,8 +38,8 @@ fn run() {
 
     let repo = &args[1];
 
-    // Parse optional VCS kind from second argument (default: Git)
-    let vcs_kind: VcsKind = args.get(2).and_then(|s| s.parse().ok()).unwrap_or_default();
+    // Parse optional VCS kind from second argument; if omitted, auto-detect later.
+    let explicit_vcs_kind: Option<VcsKind> = args.get(2).and_then(|s| s.parse().ok());
 
     // Validate all workspaces exist before attempting anything
     if let Err(msg) = config::validate_workspaces() {
@@ -72,6 +72,22 @@ fn run() {
         }
     }
 
+    // Resolve repo path once (shared by all VCS backends)
+    let repo_path = match config::workspaces()
+        .iter()
+        .map(|ws| ws.join(repo))
+        .find(|p| p.is_dir())
+    {
+        Some(p) => p,
+        None => {
+            muzzle::log::error("ensure-worktree", &format!("repo not found: {repo}"));
+            std::process::exit(1);
+        }
+    };
+
+    // Auto-detect VCS from the repo directory if not explicitly provided
+    let vcs_kind = explicit_vcs_kind.unwrap_or_else(|| muzzle::vcs::detect(&repo_path));
+
     // Create worktree — route through appropriate VCS backend
     let entry = match vcs_kind {
         VcsKind::Jj | VcsKind::JjColocated => {
@@ -79,18 +95,6 @@ fn run() {
             use muzzle::vcs::VcsBackend;
             let jj = JjBackend {
                 colocated: vcs_kind == VcsKind::JjColocated,
-            };
-            // Resolve repo path
-            let repo_path = match config::workspaces()
-                .iter()
-                .map(|ws| ws.join(repo))
-                .find(|p| p.is_dir())
-            {
-                Some(p) => p,
-                None => {
-                    muzzle::log::error("ensure-worktree", &format!("repo not found: {repo}"));
-                    std::process::exit(1);
-                }
             };
             let dest = config::worktree_path(&repo_path, &sess.short_id);
             match jj.workspace_add(&repo_path, &dest, &sess.short_id, None, &sess.tmp_dir) {

--- a/hooks/src/bin/permissions.rs
+++ b/hooks/src/bin/permissions.rs
@@ -13,6 +13,7 @@ use muzzle::mcp;
 use muzzle::output::Decision;
 use muzzle::sandbox;
 use muzzle::session;
+use muzzle::vcs::VcsKind;
 use serde::Deserialize;
 use std::io::{self, Read};
 
@@ -170,42 +171,89 @@ fn check_bash(input: &HookInput) -> Decision {
         return Decision::Allow;
     }
 
-    // Git safety checks (FR-GS-1 through FR-GS-8)
-    match gitcheck::check_git_safety(&bi.command) {
+    // Resolve session once for all checks below
+    let sess = session::resolve_readonly();
+
+    // Build JjBackend once if needed (avoids repeated construction)
+    let jj_backend: Option<muzzle::vcs::jj::JjBackend> =
+        if matches!(sess.vcs_kind, VcsKind::Jj | VcsKind::JjColocated) {
+            Some(muzzle::vcs::jj::JjBackend {
+                colocated: sess.vcs_kind == VcsKind::JjColocated,
+            })
+        } else {
+            None
+        };
+
+    // VCS-aware safety checks (FR-GS-1 through FR-GS-8)
+    let safety_result = if let Some(ref jj) = jj_backend {
+        use muzzle::vcs::VcsBackend;
+        jj.check_safety(&bi.command)
+    } else {
+        gitcheck::check_git_safety(&bi.command)
+    };
+    match safety_result {
         gitcheck::GitResult::Block(reason) => return Decision::Deny(reason),
         gitcheck::GitResult::Ok => {}
     }
 
-    // gh merge checks
+    // gh merge checks (VCS-agnostic — gh CLI works the same regardless)
     let gh_result = gitcheck::check_gh_merge(&bi.command);
     if gh_result.should_ask {
         return Decision::Ask(gh_result.reason);
     }
 
     // Worktree enforcement
-    let sess = session::resolve_readonly();
     if sess.has_session() {
-        if let Some(reason) =
-            gitcheck::check_worktree_enforcement(&bi.command, sess.worktree_active, &sess.short_id)
-        {
+        if let Some(reason) = gitcheck::check_worktree_enforcement(
+            &bi.command,
+            sess.worktree_active,
+            &sess.short_id,
+            sess.vcs_kind,
+        ) {
             return Decision::Deny(reason);
+        }
+
+        // jj workspace enforcement
+        if let Some(ref jj) = jj_backend {
+            use muzzle::vcs::VcsBackend;
+            if let Some(reason) =
+                jj.check_workspace_enforcement(&bi.command, sess.worktree_active, &sess.short_id)
+            {
+                return Decision::Deny(reason);
+            }
         }
 
         // FR-WE-2: If session exists but no worktrees, return WORKTREE_MISSING
         // so the agent can lazily create a worktree via ensure-worktree.
-        if !sess.worktree_active
-            && bi.command.contains("git")
-            && gitcheck::is_repo_git_op(&bi.command)
-            && !gitcheck::is_worktree_management_op(&bi.command)
-        {
-            if let Some(repo) = gitcheck::extract_repo_from_git_op(&bi.command) {
-                return Decision::Deny(muzzle::worktree_missing_msg(&repo));
+        if !sess.worktree_active {
+            let is_repo_op = if let Some(ref jj) = jj_backend {
+                use muzzle::vcs::VcsBackend;
+                (bi.command.contains("jj") && !jj.is_workspace_management_op(&bi.command))
+                    || (bi.command.contains("git")
+                        && gitcheck::is_repo_git_op(&bi.command)
+                        && !gitcheck::is_worktree_management_op(&bi.command))
+            } else {
+                bi.command.contains("git")
+                    && gitcheck::is_repo_git_op(&bi.command)
+                    && !gitcheck::is_worktree_management_op(&bi.command)
+            };
+            if is_repo_op {
+                let repo = if let Some(ref jj) = jj_backend {
+                    use muzzle::vcs::VcsBackend;
+                    jj.extract_repo_from_op(&bi.command)
+                        .or_else(|| gitcheck::extract_repo_from_git_op(&bi.command))
+                } else {
+                    gitcheck::extract_repo_from_git_op(&bi.command)
+                };
+                if let Some(repo) = repo {
+                    return Decision::Deny(muzzle::worktree_missing_msg(&repo, sess.vcs_kind));
+                }
+                return Decision::Deny(
+                    "BLOCKED: No worktree for this session. \
+                     Cannot determine target repo from command."
+                        .into(),
+                );
             }
-            return Decision::Deny(
-                "BLOCKED: No worktree for this session. \
-                 Cannot determine target repo from command."
-                    .into(),
-            );
         }
     }
 

--- a/hooks/src/bin/permissions.rs
+++ b/hooks/src/bin/permissions.rs
@@ -228,7 +228,8 @@ fn check_bash(input: &HookInput) -> Decision {
         if !sess.worktree_active {
             let is_repo_op = if let Some(ref jj) = jj_backend {
                 use muzzle::vcs::VcsBackend;
-                (bi.command.contains("jj") && !jj.is_workspace_management_op(&bi.command))
+                (muzzle::vcs::jj::JjBackend::is_repo_op(&bi.command)
+                    && !jj.is_workspace_management_op(&bi.command))
                     || (bi.command.contains("git")
                         && gitcheck::is_repo_git_op(&bi.command)
                         && !gitcheck::is_worktree_management_op(&bi.command))

--- a/hooks/src/bin/session_end.rs
+++ b/hooks/src/bin/session_end.rs
@@ -90,11 +90,25 @@ fn remove_worktrees(sess: &session::State) {
                 None,
                 Some(&entry.wt_path),
             );
+            let cleanup_hint = match entry.vcs_kind {
+                VcsKind::Jj | VcsKind::JjColocated => {
+                    format!(
+                        "jj workspace forget {} && rm -rf {}",
+                        entry.wt_path, entry.wt_path
+                    )
+                }
+                VcsKind::Git => {
+                    format!(
+                        "git -C {} worktree remove --force {}",
+                        entry.repo_path, entry.wt_path
+                    )
+                }
+            };
             let _ = append_to_changelog(
                 &sess.changelog_path,
                 &format!(
-                    "\n### WARNING: Uncommitted worktree left behind\n- Path: {}\n- Cleanup: `git -C {} worktree remove --force {}`\n",
-                    entry.wt_path, entry.repo_path, entry.wt_path,
+                    "\n### WARNING: Uncommitted worktree left behind\n- Path: {}\n- Cleanup: `{cleanup_hint}`\n",
+                    entry.wt_path,
                 ),
             );
             continue;

--- a/hooks/src/bin/session_end.rs
+++ b/hooks/src/bin/session_end.rs
@@ -92,9 +92,15 @@ fn remove_worktrees(sess: &session::State) {
             );
             let cleanup_hint = match entry.vcs_kind {
                 VcsKind::Jj | VcsKind::JjColocated => {
+                    // jj workspace forget takes a workspace NAME (last path component),
+                    // not a full path.
+                    let ws_name = std::path::Path::new(&entry.wt_path)
+                        .file_name()
+                        .unwrap_or_default()
+                        .to_string_lossy();
                     format!(
-                        "jj workspace forget {} && rm -rf {}",
-                        entry.wt_path, entry.wt_path
+                        "cd {} && jj workspace forget {} && rm -rf {}",
+                        entry.repo_path, ws_name, entry.wt_path
                     )
                 }
                 VcsKind::Git => {

--- a/hooks/src/bin/session_end.rs
+++ b/hooks/src/bin/session_end.rs
@@ -7,6 +7,7 @@ use flate2::write::GzEncoder;
 use flate2::Compression;
 use muzzle::config;
 use muzzle::session::{self, SpecEntry};
+use muzzle::vcs::VcsKind;
 use muzzle::worktree;
 use serde::Deserialize;
 use std::fs;
@@ -70,7 +71,17 @@ fn remove_worktrees(sess: &session::State) {
     };
 
     for entry in &entries {
-        let (dirty, err) = worktree::remove(entry);
+        let (dirty, err) = match entry.vcs_kind {
+            VcsKind::Jj | VcsKind::JjColocated => {
+                use muzzle::vcs::jj::JjBackend;
+                use muzzle::vcs::VcsBackend;
+                let jj = JjBackend {
+                    colocated: entry.vcs_kind == VcsKind::JjColocated,
+                };
+                jj.workspace_remove(entry, false)
+            }
+            VcsKind::Git => worktree::remove(entry),
+        };
         if dirty {
             muzzle::log::emit_full(
                 "WARN",

--- a/hooks/src/gitcheck.rs
+++ b/hooks/src/gitcheck.rs
@@ -172,6 +172,7 @@ pub fn check_worktree_enforcement(
     cmd: &str,
     worktree_active: bool,
     short_id: &str,
+    vcs_kind: crate::vcs::VcsKind,
 ) -> Option<String> {
     if !worktree_active {
         return None;
@@ -201,7 +202,7 @@ pub fn check_worktree_enforcement(
                     let repo = extract_repo_name(git_path, &ws_str);
                     let wt_dir = format!("{}/{}/.worktrees/{}", ws_str, repo, short_id);
                     if !std::path::Path::new(&wt_dir).exists() {
-                        return Some(crate::worktree_missing_msg(&repo));
+                        return Some(crate::worktree_missing_msg(&repo, vcs_kind));
                     }
                     return Some(format!(
                         "BLOCKED: Git op on main checkout ({repo}). \
@@ -225,7 +226,7 @@ pub fn check_worktree_enforcement(
                     let repo = extract_repo_name(cd_path, &ws_str);
                     let wt_dir = format!("{}/{}/.worktrees/{}", ws_str, repo, short_id);
                     if !std::path::Path::new(&wt_dir).exists() {
-                        return Some(crate::worktree_missing_msg(&repo));
+                        return Some(crate::worktree_missing_msg(&repo, vcs_kind));
                     }
                     return Some(format!(
                         "BLOCKED: Git op on main checkout ({repo}). \
@@ -596,7 +597,7 @@ mod tests {
         let fixed_ws = "/tmp/muzzle-test-ws";
         std::env::set_var("MUZZLE_WORKSPACE", fixed_ws);
         let cmd = format!("git -C {fixed_ws}/web-app status");
-        let reason = check_worktree_enforcement(&cmd, true, "abc12345");
+        let reason = check_worktree_enforcement(&cmd, true, "abc12345", crate::vcs::VcsKind::Git);
         std::env::remove_var("MUZZLE_WORKSPACE");
         assert!(reason.is_some(), "expected deny for git on main checkout");
     }
@@ -607,7 +608,7 @@ mod tests {
         let fixed_ws = "/tmp/muzzle-test-ws";
         std::env::set_var("MUZZLE_WORKSPACE", fixed_ws);
         let cmd = format!("git -C {fixed_ws}/web-app/.worktrees/abc12345 status");
-        let reason = check_worktree_enforcement(&cmd, true, "abc12345");
+        let reason = check_worktree_enforcement(&cmd, true, "abc12345", crate::vcs::VcsKind::Git);
         std::env::remove_var("MUZZLE_WORKSPACE");
         assert!(
             reason.is_none(),
@@ -622,7 +623,7 @@ mod tests {
         let fixed_ws = "/tmp/muzzle-test-ws";
         std::env::set_var("MUZZLE_WORKSPACE", fixed_ws);
         let cmd = format!("git -C {fixed_ws}/web-app worktree add /path");
-        let reason = check_worktree_enforcement(&cmd, true, "abc12345");
+        let reason = check_worktree_enforcement(&cmd, true, "abc12345", crate::vcs::VcsKind::Git);
         std::env::remove_var("MUZZLE_WORKSPACE");
         assert!(
             reason.is_none(),
@@ -637,14 +638,19 @@ mod tests {
         let fixed_ws = "/tmp/muzzle-test-ws";
         std::env::set_var("MUZZLE_WORKSPACE", fixed_ws);
         let cmd = format!("git -C {fixed_ws}/web-app status");
-        let reason = check_worktree_enforcement(&cmd, false, "abc12345");
+        let reason = check_worktree_enforcement(&cmd, false, "abc12345", crate::vcs::VcsKind::Git);
         std::env::remove_var("MUZZLE_WORKSPACE");
         assert!(reason.is_none(), "expected no enforcement when inactive");
     }
 
     #[test]
     fn test_worktree_enforcement_bare_checkout() {
-        let reason = check_worktree_enforcement("git checkout feature-branch", true, "abc12345");
+        let reason = check_worktree_enforcement(
+            "git checkout feature-branch",
+            true,
+            "abc12345",
+            crate::vcs::VcsKind::Git,
+        );
         assert!(reason.is_some(), "expected deny for bare git checkout");
     }
 

--- a/hooks/src/lib.rs
+++ b/hooks/src/lib.rs
@@ -18,15 +18,20 @@ pub mod mcp;
 pub mod output;
 pub mod sandbox;
 pub mod session;
+pub mod vcs;
 pub mod worktree;
 
 /// Format a WORKTREE_MISSING denial message for lazy worktree creation.
-pub fn worktree_missing_msg(repo: &str) -> String {
+///
+/// The message encodes the VCS kind so `ensure-worktree` knows which backend
+/// to use when creating the workspace on demand.
+pub fn worktree_missing_msg(repo: &str, vcs_kind: vcs::VcsKind) -> String {
     let bin = config::bin_dir().join("ensure-worktree");
     format!(
-        "WORKTREE_MISSING:{repo} \
+        "WORKTREE_MISSING:{repo}:{vcs} \
          — Run: {} {repo}",
-        bin.display()
+        bin.display(),
+        vcs = vcs_kind,
     )
 }
 
@@ -44,8 +49,8 @@ mod tests {
     #[test]
     fn test_worktree_missing_msg_format() {
         let _lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
-        let msg = worktree_missing_msg("my-repo");
-        assert!(msg.starts_with("WORKTREE_MISSING:my-repo"));
+        let msg = worktree_missing_msg("my-repo", vcs::VcsKind::Git);
+        assert!(msg.starts_with("WORKTREE_MISSING:my-repo:git"));
         assert!(msg.contains("ensure-worktree my-repo"));
         // Must contain an absolute-looking path, not the old relative one
         assert!(
@@ -57,22 +62,32 @@ mod tests {
     #[test]
     fn test_worktree_missing_msg_special_chars() {
         let _lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
-        let msg = worktree_missing_msg("repo-with-dashes");
-        assert!(msg.starts_with("WORKTREE_MISSING:repo-with-dashes"));
+        let msg = worktree_missing_msg("repo-with-dashes", vcs::VcsKind::Git);
+        assert!(msg.starts_with("WORKTREE_MISSING:repo-with-dashes:git"));
 
-        let msg = worktree_missing_msg(".dotfile-repo");
-        assert!(msg.starts_with("WORKTREE_MISSING:.dotfile-repo"));
+        let msg = worktree_missing_msg(".dotfile-repo", vcs::VcsKind::Jj);
+        assert!(msg.starts_with("WORKTREE_MISSING:.dotfile-repo:jj"));
     }
 
     #[test]
     fn test_worktree_missing_msg_uses_bin_dir() {
         let _lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         std::env::set_var("MUZZLE_BIN_DIR", "/opt/muzzle/bin");
-        let msg = worktree_missing_msg("acme-api");
+        let msg = worktree_missing_msg("acme-api", vcs::VcsKind::Git);
         std::env::remove_var("MUZZLE_BIN_DIR");
         assert!(
             msg.contains("/opt/muzzle/bin/ensure-worktree acme-api"),
             "should use MUZZLE_BIN_DIR: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_worktree_missing_msg_jj_colocated() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let msg = worktree_missing_msg("acme-api", vcs::VcsKind::JjColocated);
+        assert!(
+            msg.starts_with("WORKTREE_MISSING:acme-api:jj-coloc"),
+            "should encode jj-coloc VCS kind: {msg}"
         );
     }
 }

--- a/hooks/src/lib.rs
+++ b/hooks/src/lib.rs
@@ -29,7 +29,7 @@ pub fn worktree_missing_msg(repo: &str, vcs_kind: vcs::VcsKind) -> String {
     let bin = config::bin_dir().join("ensure-worktree");
     format!(
         "WORKTREE_MISSING:{repo}:{vcs} \
-         — Run: {} {repo}",
+         — Run: {} {repo} {vcs}",
         bin.display(),
         vcs = vcs_kind,
     )
@@ -51,7 +51,7 @@ mod tests {
         let _lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
         let msg = worktree_missing_msg("my-repo", vcs::VcsKind::Git);
         assert!(msg.starts_with("WORKTREE_MISSING:my-repo:git"));
-        assert!(msg.contains("ensure-worktree my-repo"));
+        assert!(msg.contains("ensure-worktree my-repo git"));
         // Must contain an absolute-looking path, not the old relative one
         assert!(
             !msg.contains(".claude/hooks/bin"),
@@ -76,7 +76,7 @@ mod tests {
         let msg = worktree_missing_msg("acme-api", vcs::VcsKind::Git);
         std::env::remove_var("MUZZLE_BIN_DIR");
         assert!(
-            msg.contains("/opt/muzzle/bin/ensure-worktree acme-api"),
+            msg.contains("/opt/muzzle/bin/ensure-worktree acme-api git"),
             "should use MUZZLE_BIN_DIR: {msg}"
         );
     }

--- a/hooks/src/sandbox.rs
+++ b/hooks/src/sandbox.rs
@@ -118,7 +118,8 @@ pub fn check_path_with_context(
             if sess.worktree_active {
                 // Worktrees are active — strict sandbox mode
 
-                // FR-WE-3: Allow writes to worktree paths
+                // FR-WE-3: Allow writes to worktree paths.
+                // Both git and jj backends use .worktrees/ for workspace isolation.
                 if resolved.contains("/.worktrees/") {
                     // But redirect .agents/ writes back to main checkout for persistence.
                     // E.g. <repo>/.worktrees/<id>/.agents/foo.md → <repo>/.agents/foo.md
@@ -160,7 +161,10 @@ pub fn check_path_with_context(
                     let repo = extract_repo(&resolved, ws_str);
                     let wt_dir = format!("{}/{}/.worktrees/{}", ws_str, repo, sess.short_id);
                     if !repo.is_empty() && !Path::new(&wt_dir).exists() {
-                        return PathDecision::Deny(crate::worktree_missing_msg(&repo));
+                        return PathDecision::Deny(crate::worktree_missing_msg(
+                            &repo,
+                            sess.vcs_kind,
+                        ));
                     }
                     let rel = extract_rel_path(&resolved, &repo, ws_str);
                     return PathDecision::Deny(format!(
@@ -187,7 +191,10 @@ pub fn check_path_with_context(
                     // FR-WE-2: Return WORKTREE_MISSING with repo name for lazy creation
                     let repo = extract_repo(&resolved, ws_str);
                     if !repo.is_empty() {
-                        return PathDecision::Deny(crate::worktree_missing_msg(&repo));
+                        return PathDecision::Deny(crate::worktree_missing_msg(
+                            &repo,
+                            sess.vcs_kind,
+                        ));
                     }
                     return PathDecision::Deny(
                         "BLOCKED: No worktree for this session. All repo writes are blocked to prevent editing the main checkout.".into(),
@@ -431,6 +438,7 @@ fn extract_rel_path(path: &str, repo: &str, ws: &str) -> String {
 mod tests {
     use super::*;
     use crate::config;
+    use crate::vcs::VcsKind;
     use crate::ENV_LOCK;
     use std::path::PathBuf;
 
@@ -442,6 +450,7 @@ mod tests {
             spec_file: config::spec_file_path("abc12345-test"),
             changelog_path: config::changelog_path("abc12345-test"),
             worktree_active: true,
+            vcs_kind: VcsKind::Git,
             resolved: true,
         }
     }
@@ -454,6 +463,7 @@ mod tests {
             spec_file: config::spec_file_path("abc12345-test"),
             changelog_path: config::changelog_path("abc12345-test"),
             worktree_active: false,
+            vcs_kind: VcsKind::Git,
             resolved: true,
         }
     }
@@ -466,6 +476,7 @@ mod tests {
             spec_file: PathBuf::new(),
             changelog_path: PathBuf::new(),
             worktree_active: false,
+            vcs_kind: VcsKind::Git,
             resolved: true,
         }
     }

--- a/hooks/src/session.rs
+++ b/hooks/src/session.rs
@@ -4,6 +4,7 @@
 //! no scan fallback (AR-4), per-invocation caching (FR-SI-5).
 
 use crate::config;
+use crate::vcs::VcsKind;
 use std::cell::RefCell;
 use std::fs;
 use std::io;
@@ -49,6 +50,8 @@ pub struct State {
     pub changelog_path: PathBuf,
     /// True if this session has at least one worktree registered.
     pub worktree_active: bool,
+    /// VCS backend type detected for this session's primary workspace.
+    pub vcs_kind: VcsKind,
     /// True once resolution has completed (even if no session was found).
     pub resolved: bool,
 }
@@ -63,6 +66,7 @@ impl State {
             spec_file: PathBuf::new(),
             changelog_path: PathBuf::new(),
             worktree_active: false,
+            vcs_kind: VcsKind::Git,
             resolved: true,
         }
     }
@@ -70,6 +74,10 @@ impl State {
     /// Create a fully populated state from a session ID.
     pub fn from_id(session_id: &str) -> Self {
         let worktree_active = spec_file_has_content(&config::spec_file_path(session_id));
+        let vcs_kind = match read_spec_file(&config::spec_file_path(session_id)) {
+            Ok(entries) if !entries.is_empty() => entries[0].vcs_kind,
+            _ => VcsKind::Git,
+        };
         Self {
             id: session_id.to_string(),
             short_id: config::short_id(session_id),
@@ -77,6 +85,7 @@ impl State {
             spec_file: config::spec_file_path(session_id),
             changelog_path: config::changelog_path(session_id),
             worktree_active,
+            vcs_kind,
             resolved: true,
         }
     }
@@ -221,6 +230,8 @@ pub struct SpecEntry {
     pub wt_path: String,
     /// Absolute path to the original repo root.
     pub repo_path: String,
+    /// VCS backend type for this workspace entry.
+    pub vcs_kind: VcsKind,
 }
 
 /// Read and parse the worktree spec file.
@@ -233,16 +244,27 @@ pub fn read_spec_file(path: &Path) -> Result<Vec<SpecEntry>, SessionError> {
         if line.is_empty() {
             continue;
         }
-        let parts: Vec<&str> = line.splitn(4, '|').collect();
-        if parts.len() != 4 {
-            continue;
+        let parts: Vec<&str> = line.splitn(5, '|').collect();
+        match parts.len() {
+            4 => entries.push(SpecEntry {
+                repo: parts[0].to_string(),
+                branch: parts[1].to_string(),
+                wt_path: parts[2].to_string(),
+                repo_path: parts[3].to_string(),
+                vcs_kind: VcsKind::Git, // backward compat
+            }),
+            5 => {
+                let vcs_kind = parts[4].parse::<VcsKind>().unwrap_or_default();
+                entries.push(SpecEntry {
+                    repo: parts[0].to_string(),
+                    branch: parts[1].to_string(),
+                    wt_path: parts[2].to_string(),
+                    repo_path: parts[3].to_string(),
+                    vcs_kind,
+                });
+            }
+            _ => continue,
         }
-        entries.push(SpecEntry {
-            repo: parts[0].to_string(),
-            branch: parts[1].to_string(),
-            wt_path: parts[2].to_string(),
-            repo_path: parts[3].to_string(),
-        });
     }
     Ok(entries)
 }
@@ -251,7 +273,12 @@ pub fn read_spec_file(path: &Path) -> Result<Vec<SpecEntry>, SessionError> {
 pub fn write_spec_file(path: &Path, entries: &[SpecEntry]) -> Result<(), SessionError> {
     let content: String = entries
         .iter()
-        .map(|e| format!("{}|{}|{}|{}", e.repo, e.branch, e.wt_path, e.repo_path))
+        .map(|e| {
+            format!(
+                "{}|{}|{}|{}|{}",
+                e.repo, e.branch, e.wt_path, e.repo_path, e.vcs_kind
+            )
+        })
         .collect::<Vec<_>>()
         .join("\n")
         + "\n";
@@ -467,12 +494,14 @@ mod tests {
                 branch: "wt/abc12345".into(),
                 wt_path: "/path/to/wt".into(),
                 repo_path: "/path/to/repo".into(),
+                vcs_kind: VcsKind::Git,
             },
             SpecEntry {
                 repo: "api-server".into(),
                 branch: "feature/test".into(),
                 wt_path: "/path/to/wt2".into(),
                 repo_path: "/path/to/repo2".into(),
+                vcs_kind: VcsKind::Git,
             },
         ];
 
@@ -500,6 +529,7 @@ mod tests {
             branch: "wt/abc12345".into(),
             wt_path: "/path/to/ops/wt".into(),
             repo_path: "/path/to/ops".into(),
+            vcs_kind: VcsKind::Git,
         };
 
         append_spec_entry(&spec_path, &entry).expect("append to empty failed");
@@ -525,6 +555,7 @@ mod tests {
             branch: "wt/abc12345".into(),
             wt_path: "/path/to/web-app/wt".into(),
             repo_path: "/path/to/web-app".into(),
+            vcs_kind: VcsKind::Git,
         }];
         write_spec_file(&spec_path, &entries).expect("initial write failed");
 
@@ -534,6 +565,7 @@ mod tests {
             branch: "wt/abc12345".into(),
             wt_path: "/path/to/ops/wt".into(),
             repo_path: "/path/to/ops".into(),
+            vcs_kind: VcsKind::Git,
         };
         append_spec_entry(&spec_path, &new_entry).expect("append failed");
 
@@ -558,6 +590,7 @@ mod tests {
             branch: "wt/abc12345".into(),
             wt_path: "/path/to/ops/wt".into(),
             repo_path: "/path/to/ops".into(),
+            vcs_kind: VcsKind::Git,
         };
 
         append_spec_entry(&spec_path, &entry).expect("first append failed");
@@ -810,5 +843,80 @@ mod tests {
         assert_eq!(data, "test-register-session");
 
         reset_cache();
+    }
+
+    #[test]
+    fn test_spec_entry_5_field_roundtrip() {
+        let tmp = std::env::temp_dir().join("muzzle-test-spec-5field");
+        let _ = fs::create_dir_all(&tmp);
+        let spec_path = tmp.join("roundtrip.env");
+
+        let entries = vec![
+            SpecEntry {
+                repo: "acme-api".into(),
+                branch: "wt/abc12345".into(),
+                wt_path: "/path/to/wt".into(),
+                repo_path: "/path/to/repo".into(),
+                vcs_kind: VcsKind::Git,
+            },
+            SpecEntry {
+                repo: "web-app".into(),
+                branch: "wt/def67890".into(),
+                wt_path: "/path/to/wt2".into(),
+                repo_path: "/path/to/repo2".into(),
+                vcs_kind: VcsKind::Jj,
+            },
+            SpecEntry {
+                repo: "infra".into(),
+                branch: "wt/ghi11111".into(),
+                wt_path: "/path/to/wt3".into(),
+                repo_path: "/path/to/repo3".into(),
+                vcs_kind: VcsKind::JjColocated,
+            },
+        ];
+
+        write_spec_file(&spec_path, &entries).expect("write failed");
+        let read_entries = read_spec_file(&spec_path).expect("read failed");
+
+        assert_eq!(read_entries.len(), 3);
+        assert_eq!(read_entries[0].vcs_kind, VcsKind::Git);
+        assert_eq!(read_entries[1].vcs_kind, VcsKind::Jj);
+        assert_eq!(read_entries[2].vcs_kind, VcsKind::JjColocated);
+        assert_eq!(read_entries[0].repo, "acme-api");
+        assert_eq!(read_entries[1].repo, "web-app");
+        assert_eq!(read_entries[2].repo, "infra");
+
+        let _ = fs::remove_file(&spec_path);
+        let _ = fs::remove_dir(&tmp);
+    }
+
+    #[test]
+    fn test_spec_entry_4_field_backward_compat() {
+        let tmp = std::env::temp_dir().join("muzzle-test-spec-4field");
+        let _ = fs::create_dir_all(&tmp);
+        let spec_path = tmp.join("legacy.env");
+
+        // Write legacy 4-field format manually (no vcs_kind column)
+        let content = "acme-api|main|/path/to/wt|/path/to/repo\n\
+                        web-app|develop|/path/to/wt2|/path/to/repo2\n";
+        fs::write(&spec_path, content).expect("write failed");
+
+        let entries = read_spec_file(&spec_path).expect("read failed");
+        assert_eq!(entries.len(), 2);
+        assert_eq!(
+            entries[0].vcs_kind,
+            VcsKind::Git,
+            "legacy 4-field entry should default to Git"
+        );
+        assert_eq!(
+            entries[1].vcs_kind,
+            VcsKind::Git,
+            "legacy 4-field entry should default to Git"
+        );
+        assert_eq!(entries[0].repo, "acme-api");
+        assert_eq!(entries[1].repo, "web-app");
+
+        let _ = fs::remove_file(&spec_path);
+        let _ = fs::remove_dir(&tmp);
     }
 }

--- a/hooks/src/session.rs
+++ b/hooks/src/session.rs
@@ -73,16 +73,16 @@ impl State {
 
     /// Create a fully populated state from a session ID.
     pub fn from_id(session_id: &str) -> Self {
-        let worktree_active = spec_file_has_content(&config::spec_file_path(session_id));
-        let vcs_kind = match read_spec_file(&config::spec_file_path(session_id)) {
-            Ok(entries) if !entries.is_empty() => entries[0].vcs_kind,
-            _ => VcsKind::Git,
+        let spec_path = config::spec_file_path(session_id);
+        let (worktree_active, vcs_kind) = match read_spec_file(&spec_path) {
+            Ok(entries) if !entries.is_empty() => (true, entries[0].vcs_kind),
+            _ => (false, VcsKind::Git),
         };
         Self {
             id: session_id.to_string(),
             short_id: config::short_id(session_id),
             tmp_dir: config::session_tmp_dir(session_id),
-            spec_file: config::spec_file_path(session_id),
+            spec_file: spec_path,
             changelog_path: config::changelog_path(session_id),
             worktree_active,
             vcs_kind,
@@ -352,11 +352,6 @@ fn flock_unlock(file: &fs::File) {
     }
 }
 
-/// Check if the spec file exists and has content.
-fn spec_file_has_content(path: &Path) -> bool {
-    fs::metadata(path).map(|m| m.len() > 0).unwrap_or(false)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -365,6 +360,11 @@ mod tests {
 
     // Serialize session tests to avoid PPID marker conflicts.
     static SESSION_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Check if the spec file exists and has content (test-only helper).
+    fn spec_file_has_content(path: &Path) -> bool {
+        fs::metadata(path).map(|m| m.len() > 0).unwrap_or(false)
+    }
 
     #[test]
     fn test_resolve_with_id() {

--- a/hooks/src/vcs/git.rs
+++ b/hooks/src/vcs/git.rs
@@ -1,0 +1,222 @@
+//! Git backend for [`VcsBackend`] trait.
+//!
+//! Delegates every trait method to existing functions in [`crate::worktree::git`],
+//! [`crate::worktree::cleanup`], and [`crate::gitcheck`]. No new behavior — pure
+//! delegation.
+
+use crate::config;
+use crate::gitcheck::{self, AskResult, GitResult};
+use crate::session::SpecEntry;
+use crate::vcs::{VcsBackend, VcsKind, WorkspaceInfo};
+use crate::worktree::{cleanup, git};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Git backend using git worktrees for session isolation.
+///
+/// Zero-size struct — all state lives in the repository itself.
+pub struct GitBackend;
+
+impl VcsBackend for GitBackend {
+    fn kind(&self) -> VcsKind {
+        VcsKind::Git
+    }
+
+    fn workspace_add(
+        &self,
+        repo_path: &Path,
+        dest: &Path,
+        session_id: &str,
+        branch: Option<&str>,
+        tmp_dir: &Path,
+    ) -> Result<SpecEntry, String> {
+        let repo_str = repo_path.to_string_lossy().to_string();
+        let wt_path = config::worktree_path(repo_path, session_id);
+
+        // Ensure .worktrees dir exists.
+        std::fs::create_dir_all(config::worktree_dir(repo_path))
+            .map_err(|e| format!("failed to create worktree dir: {e}"))?;
+
+        // Fetch and resolve default branch.
+        let default_branch = git::fetch_and_resolve_default_branch(repo_path, tmp_dir);
+
+        // Determine branch strategy (mirrors create_single_worktree in worktree/mod.rs).
+        let (actual_branch, args) = match branch {
+            None => {
+                // No branch specified: create ephemeral wt/<short-id>.
+                let br = format!("wt/{session_id}");
+                let args = vec![
+                    "-C".into(),
+                    repo_str.clone(),
+                    "worktree".into(),
+                    "add".into(),
+                    "-b".into(),
+                    br.clone(),
+                    wt_path.to_string_lossy().to_string(),
+                    format!("origin/{default_branch}"),
+                ];
+                (br, args)
+            }
+            Some(b) if b == default_branch => {
+                // Default branch requested: redirect to ephemeral (don't lock default).
+                let br = format!("wt/{session_id}");
+                let args = vec![
+                    "-C".into(),
+                    repo_str.clone(),
+                    "worktree".into(),
+                    "add".into(),
+                    "-b".into(),
+                    br.clone(),
+                    wt_path.to_string_lossy().to_string(),
+                    format!("origin/{default_branch}"),
+                ];
+                (br, args)
+            }
+            Some(b) if git::branch_exists(repo_path, b) => {
+                // Existing branch: check it out.
+                let args = vec![
+                    "-C".into(),
+                    repo_str.clone(),
+                    "worktree".into(),
+                    "add".into(),
+                    wt_path.to_string_lossy().to_string(),
+                    b.into(),
+                ];
+                (b.to_string(), args)
+            }
+            Some(b) => {
+                // New branch: create from origin/<default>.
+                let args = vec![
+                    "-C".into(),
+                    repo_str.clone(),
+                    "worktree".into(),
+                    "add".into(),
+                    "-b".into(),
+                    b.into(),
+                    wt_path.to_string_lossy().to_string(),
+                    format!("origin/{default_branch}"),
+                ];
+                (b.to_string(), args)
+            }
+        };
+
+        // First attempt.
+        if git::run_git_strings(&args).is_err() {
+            // Retry after prune.
+            let _ = git::run_git(&["-C", &repo_str, "worktree", "prune"]);
+            if let Err(e) = git::run_git_strings(&args) {
+                // Clean up partial worktree.
+                let _ = std::fs::remove_dir_all(&wt_path);
+                return Err(format!("git worktree add failed (after retry): {e}"));
+            }
+        }
+
+        let repo_name = dest
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_string();
+
+        Ok(SpecEntry {
+            repo: repo_name,
+            branch: actual_branch,
+            wt_path: wt_path.to_string_lossy().to_string(),
+            repo_path: repo_path.to_string_lossy().to_string(),
+            vcs_kind: VcsKind::Git,
+        })
+    }
+
+    fn workspace_remove(&self, entry: &SpecEntry, force: bool) -> (bool, Option<String>) {
+        if force {
+            let err = git::run_git(&[
+                "-C",
+                &entry.repo_path,
+                "worktree",
+                "remove",
+                "--force",
+                &entry.wt_path,
+            ])
+            .err();
+            (false, err)
+        } else {
+            cleanup::remove(entry)
+        }
+    }
+
+    fn workspace_list(&self, repo_path: &Path) -> Vec<WorkspaceInfo> {
+        git::get_active_worktrees(repo_path)
+            .into_iter()
+            .map(|path| {
+                let pb = PathBuf::from(&path);
+                WorkspaceInfo {
+                    name: pb
+                        .file_name()
+                        .unwrap_or_default()
+                        .to_string_lossy()
+                        .to_string(),
+                    path: pb,
+                }
+            })
+            .collect()
+    }
+
+    fn workspace_prune(&self, repo_path: &Path) {
+        cleanup::prune_stale_worktrees(repo_path);
+    }
+
+    fn is_clean(&self, path: &Path) -> bool {
+        Command::new("git")
+            .args([
+                "-C",
+                &path.to_string_lossy(),
+                "diff-index",
+                "--quiet",
+                "HEAD",
+                "--",
+            ])
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    }
+
+    fn fetch(&self, repo_path: &Path, tmp_dir: &Path) {
+        git::fetch_origin(repo_path, tmp_dir);
+    }
+
+    fn default_branch(&self, repo_path: &Path, tmp_dir: &Path) -> String {
+        git::fetch_and_resolve_default_branch(repo_path, tmp_dir)
+    }
+
+    fn is_repo(&self, path: &Path) -> bool {
+        git::is_git_repo(path)
+    }
+
+    fn is_valid_workspace(&self, path: &str) -> bool {
+        git::is_valid_worktree(path)
+    }
+
+    fn check_safety(&self, cmd: &str) -> GitResult {
+        gitcheck::check_git_safety(cmd)
+    }
+
+    fn check_ask(&self, cmd: &str) -> AskResult {
+        gitcheck::check_gh_merge(cmd)
+    }
+
+    fn check_workspace_enforcement(
+        &self,
+        cmd: &str,
+        workspace_active: bool,
+        short_id: &str,
+    ) -> Option<String> {
+        gitcheck::check_worktree_enforcement(cmd, workspace_active, short_id, self.kind())
+    }
+
+    fn extract_repo_from_op(&self, cmd: &str) -> Option<String> {
+        gitcheck::extract_repo_from_git_op(cmd)
+    }
+
+    fn is_workspace_management_op(&self, cmd: &str) -> bool {
+        gitcheck::is_worktree_management_op(cmd)
+    }
+}

--- a/hooks/src/vcs/git.rs
+++ b/hooks/src/vcs/git.rs
@@ -17,6 +17,27 @@ use std::process::Command;
 /// Zero-size struct — all state lives in the repository itself.
 pub struct GitBackend;
 
+/// Build args for an ephemeral `wt/<session_id>` branch worktree creation.
+fn ephemeral_worktree_args(
+    session_id: &str,
+    repo_str: &str,
+    wt_path: &Path,
+    default_branch: &str,
+) -> (String, Vec<String>) {
+    let br = format!("wt/{session_id}");
+    let args = vec![
+        "-C".into(),
+        repo_str.to_string(),
+        "worktree".into(),
+        "add".into(),
+        "-b".into(),
+        br.clone(),
+        wt_path.to_string_lossy().to_string(),
+        format!("origin/{default_branch}"),
+    ];
+    (br, args)
+}
+
 impl VcsBackend for GitBackend {
     fn kind(&self) -> VcsKind {
         VcsKind::Git
@@ -44,33 +65,11 @@ impl VcsBackend for GitBackend {
         let (actual_branch, args) = match branch {
             None => {
                 // No branch specified: create ephemeral wt/<short-id>.
-                let br = format!("wt/{session_id}");
-                let args = vec![
-                    "-C".into(),
-                    repo_str.clone(),
-                    "worktree".into(),
-                    "add".into(),
-                    "-b".into(),
-                    br.clone(),
-                    wt_path.to_string_lossy().to_string(),
-                    format!("origin/{default_branch}"),
-                ];
-                (br, args)
+                ephemeral_worktree_args(session_id, &repo_str, &wt_path, &default_branch)
             }
             Some(b) if b == default_branch => {
                 // Default branch requested: redirect to ephemeral (don't lock default).
-                let br = format!("wt/{session_id}");
-                let args = vec![
-                    "-C".into(),
-                    repo_str.clone(),
-                    "worktree".into(),
-                    "add".into(),
-                    "-b".into(),
-                    br.clone(),
-                    wt_path.to_string_lossy().to_string(),
-                    format!("origin/{default_branch}"),
-                ];
-                (br, args)
+                ephemeral_worktree_args(session_id, &repo_str, &wt_path, &default_branch)
             }
             Some(b) if git::branch_exists(repo_path, b) => {
                 // Existing branch: check it out.

--- a/hooks/src/vcs/git.rs
+++ b/hooks/src/vcs/git.rs
@@ -52,7 +52,7 @@ impl VcsBackend for GitBackend {
         tmp_dir: &Path,
     ) -> Result<SpecEntry, String> {
         let repo_str = repo_path.to_string_lossy().to_string();
-        let wt_path = config::worktree_path(repo_path, session_id);
+        let wt_path = dest.to_path_buf();
 
         // Ensure .worktrees dir exists.
         std::fs::create_dir_all(config::worktree_dir(repo_path))
@@ -110,7 +110,7 @@ impl VcsBackend for GitBackend {
             }
         }
 
-        let repo_name = dest
+        let repo_name = repo_path
             .file_name()
             .unwrap_or_default()
             .to_string_lossy()

--- a/hooks/src/vcs/jj.rs
+++ b/hooks/src/vcs/jj.rs
@@ -1,0 +1,318 @@
+//! Jujutsu (jj) backend for [`VcsBackend`] trait.
+//!
+//! Provides workspace management and safety checks for Jujutsu repositories,
+//! including colocated mode where both `.jj/` and `.git/` are present.
+
+use crate::gitcheck::{self, AskResult, GitResult};
+use crate::session::SpecEntry;
+use crate::vcs::{VcsBackend, VcsKind, WorkspaceInfo};
+use regex::Regex;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::LazyLock;
+
+/// Jujutsu (jj) backend using jj workspaces for session isolation.
+pub struct JjBackend {
+    /// True if the repo is colocated (`.jj/` + `.git/`).
+    pub colocated: bool,
+}
+
+// Pre-compiled regexes for jj safety patterns.
+static RE_JJ_GIT_PUSH: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\bjj\s+git\s+push\b").unwrap());
+static RE_JJ_PUSH_BOOKMARK: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\bjj\s+git\s+push\b.*(-b|--bookmark)\s+").unwrap());
+static RE_JJ_BOOKMARK_DELETE_MAIN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\bjj\s+bookmark\s+delete\s+(main|master|trunk)\b").unwrap());
+static RE_JJ_REPO_FLAG: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\bjj\s+-R\s+(\S+)").unwrap());
+static RE_JJ_WORKSPACE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\bjj\s+workspace\b").unwrap());
+static RE_JJ_EDIT_IMMUTABLE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\bjj\s+edit\s+(root|trunk)\b").unwrap());
+
+impl VcsBackend for JjBackend {
+    fn kind(&self) -> VcsKind {
+        if self.colocated {
+            VcsKind::JjColocated
+        } else {
+            VcsKind::Jj
+        }
+    }
+
+    fn workspace_add(
+        &self,
+        repo_path: &Path,
+        dest: &Path,
+        session_id: &str,
+        _branch: Option<&str>,
+        _tmp_dir: &Path,
+    ) -> Result<SpecEntry, String> {
+        let repo_str = repo_path.to_string_lossy();
+        let dest_str = dest.to_string_lossy();
+
+        let status = Command::new("jj")
+            .args(["workspace", "add", &dest_str, "--name", session_id])
+            .current_dir(repo_path)
+            .status()
+            .map_err(|e| format!("failed to run jj workspace add: {e}"))?;
+
+        if !status.success() {
+            return Err(format!("jj workspace add failed for {dest_str}"));
+        }
+
+        let repo_name = repo_path
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_string();
+
+        Ok(SpecEntry {
+            repo: repo_name,
+            branch: String::new(), // jj workspaces aren't branch-bound
+            wt_path: dest_str.to_string(),
+            repo_path: repo_str.to_string(),
+            vcs_kind: self.kind(),
+        })
+    }
+
+    fn workspace_remove(&self, entry: &SpecEntry, _force: bool) -> (bool, Option<String>) {
+        // Run forget from repo root (workspace dir may be in a bad state).
+        let ws_name = std::path::Path::new(&entry.wt_path)
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_string();
+        let forget_status = Command::new("jj")
+            .args(["workspace", "forget", &ws_name])
+            .current_dir(&entry.repo_path)
+            .status();
+
+        match forget_status {
+            Ok(status) if status.success() => {}
+            Ok(_) => {
+                return (
+                    false,
+                    Some(format!("jj workspace forget failed for {}", entry.wt_path)),
+                );
+            }
+            Err(e) => {
+                return (
+                    false,
+                    Some(format!("failed to run jj workspace forget: {e}")),
+                );
+            }
+        }
+
+        if let Err(e) = std::fs::remove_dir_all(&entry.wt_path) {
+            return (
+                false,
+                Some(format!("failed to remove {}: {e}", entry.wt_path)),
+            );
+        }
+
+        (true, None)
+    }
+
+    fn workspace_list(&self, repo_path: &Path) -> Vec<WorkspaceInfo> {
+        let output = Command::new("jj")
+            .args(["workspace", "list"])
+            .current_dir(repo_path)
+            .output();
+
+        let output = match output {
+            Ok(o) if o.status.success() => o,
+            _ => return Vec::new(),
+        };
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        stdout
+            .lines()
+            .filter_map(|line| {
+                // Format: "name: <revision> (at <path>)"
+                let name = line.split(':').next()?.trim().to_string();
+                let path = if let Some(start) = line.find("(at ") {
+                    let rest = &line[start + 4..];
+                    rest.strip_suffix(')').unwrap_or(rest).trim().to_string()
+                } else {
+                    return Some(WorkspaceInfo {
+                        name,
+                        path: PathBuf::new(),
+                    });
+                };
+                Some(WorkspaceInfo {
+                    name,
+                    path: PathBuf::from(path),
+                })
+            })
+            .collect()
+    }
+
+    fn workspace_prune(&self, _repo_path: &Path) {
+        // No-op: jj handles stale workspaces automatically.
+    }
+
+    fn is_clean(&self, _path: &Path) -> bool {
+        // jj auto-snapshots working copy changes, so the workspace is
+        // effectively always clean from a conflict perspective.
+        true
+    }
+
+    fn fetch(&self, repo_path: &Path, _tmp_dir: &Path) {
+        let _ = Command::new("jj")
+            .args(["git", "fetch"])
+            .current_dir(repo_path)
+            .status();
+    }
+
+    fn default_branch(&self, repo_path: &Path, _tmp_dir: &Path) -> String {
+        let output = Command::new("jj")
+            .args(["bookmark", "list"])
+            .current_dir(repo_path)
+            .output();
+
+        if let Ok(o) = output {
+            let stdout = String::from_utf8_lossy(&o.stdout);
+            for candidate in &["main", "master", "trunk"] {
+                if stdout.lines().any(|l| l.starts_with(candidate)) {
+                    return (*candidate).to_string();
+                }
+            }
+        }
+        "main".to_string()
+    }
+
+    fn is_repo(&self, path: &Path) -> bool {
+        path.join(".jj").is_dir()
+    }
+
+    fn is_valid_workspace(&self, path: &str) -> bool {
+        Path::new(path).join(".jj").is_dir()
+    }
+
+    fn check_safety(&self, cmd: &str) -> GitResult {
+        // Block bare `jj git push` without explicit bookmark flag.
+        if RE_JJ_GIT_PUSH.is_match(cmd) && !RE_JJ_PUSH_BOOKMARK.is_match(cmd) {
+            return GitResult::Block(
+                "jj git push requires explicit -b/--bookmark flag".to_string(),
+            );
+        }
+
+        // Block deletion of protected bookmarks.
+        if RE_JJ_BOOKMARK_DELETE_MAIN.is_match(cmd) {
+            return GitResult::Block(
+                "refusing to delete protected bookmark (main/master/trunk)".to_string(),
+            );
+        }
+
+        // In colocated mode, also enforce git safety for raw git commands.
+        if self.colocated {
+            let git_result = gitcheck::check_git_safety(cmd);
+            if git_result != GitResult::Ok {
+                return git_result;
+            }
+        }
+
+        GitResult::Ok
+    }
+
+    fn check_ask(&self, _cmd: &str) -> AskResult {
+        // jj has no merge equivalent that needs user confirmation.
+        AskResult {
+            should_ask: false,
+            reason: String::new(),
+        }
+    }
+
+    fn check_workspace_enforcement(
+        &self,
+        cmd: &str,
+        workspace_active: bool,
+        short_id: &str,
+    ) -> Option<String> {
+        if workspace_active && RE_JJ_EDIT_IMMUTABLE.is_match(cmd) {
+            return Some(format!(
+                "blocked: jj edit of immutable revision in workspace {short_id}"
+            ));
+        }
+
+        // In colocated mode, also enforce git worktree rules for raw git commands.
+        if self.colocated {
+            let git_enforcement =
+                gitcheck::check_worktree_enforcement(cmd, workspace_active, short_id, self.kind());
+            if git_enforcement.is_some() {
+                return git_enforcement;
+            }
+        }
+
+        None
+    }
+
+    fn extract_repo_from_op(&self, cmd: &str) -> Option<String> {
+        RE_JJ_REPO_FLAG.captures(cmd).map(|caps| {
+            let path_str = caps.get(1).unwrap().as_str();
+            Path::new(path_str)
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .to_string()
+        })
+    }
+
+    fn is_workspace_management_op(&self, cmd: &str) -> bool {
+        RE_JJ_WORKSPACE.is_match(cmd)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_jj_safety_bare_push_blocked() {
+        let backend = JjBackend { colocated: false };
+        let result = backend.check_safety("jj git push");
+        assert!(
+            matches!(result, GitResult::Block(_)),
+            "bare jj git push should be blocked"
+        );
+    }
+
+    #[test]
+    fn test_jj_safety_bookmark_push_allowed() {
+        let backend = JjBackend { colocated: false };
+        let result = backend.check_safety("jj git push -b feature");
+        assert_eq!(result, GitResult::Ok, "push with -b flag should be allowed");
+    }
+
+    #[test]
+    fn test_jj_safety_delete_main_blocked() {
+        let backend = JjBackend { colocated: false };
+        let result = backend.check_safety("jj bookmark delete main");
+        assert!(
+            matches!(result, GitResult::Block(_)),
+            "deleting main bookmark should be blocked"
+        );
+    }
+
+    #[test]
+    fn test_jj_safety_delete_feature_allowed() {
+        let backend = JjBackend { colocated: false };
+        let result = backend.check_safety("jj bookmark delete feature-x");
+        assert_eq!(
+            result,
+            GitResult::Ok,
+            "deleting feature bookmark should be allowed"
+        );
+    }
+
+    #[test]
+    fn test_jj_colocated_git_safety() {
+        let backend = JjBackend { colocated: true };
+        let result = backend.check_safety("git push --force");
+        assert!(
+            matches!(result, GitResult::Block(_)),
+            "colocated mode should block dangerous git commands"
+        );
+    }
+}

--- a/hooks/src/vcs/jj.rs
+++ b/hooks/src/vcs/jj.rs
@@ -21,7 +21,7 @@ pub struct JjBackend {
 static RE_JJ_GIT_PUSH: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"\bjj\s+git\s+push\b").unwrap());
 static RE_JJ_PUSH_BOOKMARK: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"\bjj\s+git\s+push\b.*(-b|--bookmark)\s+").unwrap());
+    LazyLock::new(|| Regex::new(r"\bjj\s+git\s+push\b.*(-b\s+|--bookmark[\s=])").unwrap());
 static RE_JJ_BOOKMARK_DELETE_MAIN: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"\bjj\s+bookmark\s+delete\s+(main|master|trunk)\b").unwrap());
 static RE_JJ_REPO_FLAG: LazyLock<Regex> =
@@ -127,7 +127,9 @@ impl VcsBackend for JjBackend {
             );
         }
 
-        (true, None)
+        // (false, None) = success: not dirty, no error.
+        // jj auto-snapshots, so the workspace is never "dirty" in the git sense.
+        (false, None)
     }
 
     fn workspace_list(&self, repo_path: &Path) -> Vec<WorkspaceInfo> {
@@ -304,6 +306,17 @@ mod tests {
         let backend = JjBackend { colocated: false };
         let result = backend.check_safety("jj git push -b feature");
         assert_eq!(result, GitResult::Ok, "push with -b flag should be allowed");
+    }
+
+    #[test]
+    fn test_jj_safety_bookmark_push_equals_form_allowed() {
+        let backend = JjBackend { colocated: false };
+        let result = backend.check_safety("jj git push --bookmark=my-feature");
+        assert_eq!(
+            result,
+            GitResult::Ok,
+            "push with --bookmark= form should be allowed"
+        );
     }
 
     #[test]

--- a/hooks/src/vcs/jj.rs
+++ b/hooks/src/vcs/jj.rs
@@ -31,6 +31,9 @@ static RE_JJ_WORKSPACE: LazyLock<Regex> =
 static RE_JJ_EDIT_IMMUTABLE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"\bjj\s+edit\s+(root|trunk)\b").unwrap());
 
+/// Matches any `jj` command invocation (word-boundary safe).
+static RE_JJ_CMD: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\bjj\s+\w+").unwrap());
+
 /// Matches jj subcommands that are utility-only and don't operate on repo state.
 static RE_JJ_SAFE_SUBCOMMAND: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"\bjj\s+(version|help|config|init)\b").unwrap());
@@ -38,8 +41,19 @@ static RE_JJ_SAFE_SUBCOMMAND: LazyLock<Regex> =
 impl JjBackend {
     /// Check if a jj command operates on the repository (not just a utility command
     /// like `jj version` or `jj help`).
+    ///
+    /// Uses `RE_JJ_GIT_PUSH` word-boundary matching (`\bjj\b`) to avoid false
+    /// positives on unrelated commands containing "jj" as a substring (e.g.
+    /// `mkdir jj-workspace`).
     pub fn is_repo_op(cmd: &str) -> bool {
-        cmd.contains("jj") && !RE_JJ_SAFE_SUBCOMMAND.is_match(cmd)
+        // RE_JJ_GIT_PUSH and other jj regexes all use \bjj\b word boundaries.
+        // Use a simple word-boundary check here too.
+        RE_JJ_WORKSPACE.is_match(cmd)
+            || RE_JJ_GIT_PUSH.is_match(cmd)
+            || RE_JJ_EDIT_IMMUTABLE.is_match(cmd)
+            || RE_JJ_BOOKMARK_DELETE_MAIN.is_match(cmd)
+            || RE_JJ_REPO_FLAG.is_match(cmd)
+            || (RE_JJ_CMD.is_match(cmd) && !RE_JJ_SAFE_SUBCOMMAND.is_match(cmd))
     }
 }
 
@@ -192,8 +206,11 @@ impl VcsBackend for JjBackend {
 
         if let Ok(o) = output {
             let stdout = String::from_utf8_lossy(&o.stdout);
+            // Match "name: ..." exactly — use "name:" to avoid prefix false
+            // positives (e.g. "mainline" matching "main").
             for candidate in &["main", "master", "trunk"] {
-                if stdout.lines().any(|l| l.starts_with(candidate)) {
+                let prefix = format!("{candidate}:");
+                if stdout.lines().any(|l| l.starts_with(&prefix)) {
                     return (*candidate).to_string();
                 }
             }

--- a/hooks/src/vcs/jj.rs
+++ b/hooks/src/vcs/jj.rs
@@ -31,6 +31,18 @@ static RE_JJ_WORKSPACE: LazyLock<Regex> =
 static RE_JJ_EDIT_IMMUTABLE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"\bjj\s+edit\s+(root|trunk)\b").unwrap());
 
+/// Matches jj subcommands that are utility-only and don't operate on repo state.
+static RE_JJ_SAFE_SUBCOMMAND: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\bjj\s+(version|help|config|init)\b").unwrap());
+
+impl JjBackend {
+    /// Check if a jj command operates on the repository (not just a utility command
+    /// like `jj version` or `jj help`).
+    pub fn is_repo_op(cmd: &str) -> bool {
+        cmd.contains("jj") && !RE_JJ_SAFE_SUBCOMMAND.is_match(cmd)
+    }
+}
+
 impl VcsBackend for JjBackend {
     fn kind(&self) -> VcsKind {
         if self.colocated {
@@ -77,6 +89,10 @@ impl VcsBackend for JjBackend {
     }
 
     fn workspace_remove(&self, entry: &SpecEntry, _force: bool) -> (bool, Option<String>) {
+        // jj workspace forget is always safe — jj auto-snapshots all working
+        // copy changes, so there's no risk of data loss. The `force` parameter
+        // is a no-op for this backend.
+        //
         // Run forget from repo root (workspace dir may be in a bad state).
         let ws_name = std::path::Path::new(&entry.wt_path)
             .file_name()
@@ -129,21 +145,22 @@ impl VcsBackend for JjBackend {
         stdout
             .lines()
             .filter_map(|line| {
-                // Format: "name: <revision> (at <path>)"
+                // Format: "name: <change-id> <commit-id> <description>"
+                // Non-default workspaces may include "(at <path>)" but this
+                // isn't guaranteed across jj versions. Derive paths from the
+                // repo root as a best-effort fallback.
                 let name = line.split(':').next()?.trim().to_string();
                 let path = if let Some(start) = line.find("(at ") {
                     let rest = &line[start + 4..];
-                    rest.strip_suffix(')').unwrap_or(rest).trim().to_string()
+                    PathBuf::from(rest.strip_suffix(')').unwrap_or(rest).trim())
+                } else if name == "default" {
+                    // The default workspace lives at the repo root.
+                    repo_path.to_path_buf()
                 } else {
-                    return Some(WorkspaceInfo {
-                        name,
-                        path: PathBuf::new(),
-                    });
+                    // Non-default workspaces: best-effort, path unknown.
+                    PathBuf::new()
                 };
-                Some(WorkspaceInfo {
-                    name,
-                    path: PathBuf::from(path),
-                })
+                Some(WorkspaceInfo { name, path })
             })
             .collect()
     }
@@ -187,7 +204,11 @@ impl VcsBackend for JjBackend {
     }
 
     fn is_valid_workspace(&self, path: &str) -> bool {
-        Path::new(path).join(".jj").is_dir()
+        let p = Path::new(path);
+        // A jj workspace is valid if the directory exists AND either contains
+        // the `.jj/` store (repo root) or lives under a `.worktrees/` parent
+        // (session workspace created by muzzle).
+        p.is_dir() && (p.join(".jj").exists() || path.contains("/.worktrees/"))
     }
 
     fn check_safety(&self, cmd: &str) -> GitResult {

--- a/hooks/src/vcs/mod.rs
+++ b/hooks/src/vcs/mod.rs
@@ -1,0 +1,200 @@
+//! VCS backend abstraction layer.
+//!
+//! Provides a trait-based interface for version control operations, enabling
+//! muzzle to work with both Git and Jujutsu (jj) repositories. The [`detect`]
+//! function probes a directory for `.jj/` and `.git/` markers to determine
+//! which backend to use.
+
+pub mod git;
+pub mod jj;
+
+use crate::gitcheck::{AskResult, GitResult};
+use crate::session::SpecEntry;
+use std::path::{Path, PathBuf};
+
+/// The kind of version control system detected for a repository.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub enum VcsKind {
+    /// Standard Git repository.
+    #[default]
+    Git,
+    /// Pure Jujutsu repository (no colocated Git).
+    Jj,
+    /// Jujutsu repository colocated with Git (both `.jj/` and `.git/` present).
+    JjColocated,
+}
+
+impl std::fmt::Display for VcsKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            VcsKind::Git => write!(f, "git"),
+            VcsKind::Jj => write!(f, "jj"),
+            VcsKind::JjColocated => write!(f, "jj-coloc"),
+        }
+    }
+}
+
+impl std::str::FromStr for VcsKind {
+    type Err = String;
+
+    /// Parse a [`VcsKind`] from its string representation.
+    ///
+    /// Accepts the same strings produced by [`Display`]: `"git"`, `"jj"`,
+    /// `"jj-coloc"`. Returns `Err` with a descriptive message for unknown
+    /// values.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "git" => Ok(VcsKind::Git),
+            "jj" => Ok(VcsKind::Jj),
+            "jj-coloc" => Ok(VcsKind::JjColocated),
+            other => Err(format!("unknown VCS kind: {other:?}")),
+        }
+    }
+}
+
+/// Information about a VCS workspace (worktree in Git, workspace in jj).
+#[derive(Debug, Clone)]
+pub struct WorkspaceInfo {
+    /// Workspace name (e.g. branch name or jj workspace identifier).
+    pub name: String,
+    /// Absolute path to the workspace directory.
+    pub path: PathBuf,
+}
+
+/// Trait abstracting version control operations for workspace management and
+/// safety checks.
+///
+/// Implementations exist for Git ([`git`] module) and Jujutsu ([`jj`] module).
+/// The trait is used as a generic bound, not as a trait object.
+pub trait VcsBackend {
+    /// Return the VCS kind this backend handles.
+    fn kind(&self) -> VcsKind;
+
+    /// Create a new workspace (worktree) for the given repository.
+    fn workspace_add(
+        &self,
+        repo_path: &Path,
+        dest: &Path,
+        session_id: &str,
+        branch: Option<&str>,
+        tmp_dir: &Path,
+    ) -> Result<SpecEntry, String>;
+
+    /// Remove a workspace. Returns `(success, optional_error_message)`.
+    fn workspace_remove(&self, entry: &SpecEntry, force: bool) -> (bool, Option<String>);
+
+    /// List all workspaces for a repository.
+    fn workspace_list(&self, repo_path: &Path) -> Vec<WorkspaceInfo>;
+
+    /// Prune stale workspace references.
+    fn workspace_prune(&self, repo_path: &Path);
+
+    /// Check whether the working directory is clean (no uncommitted changes).
+    fn is_clean(&self, path: &Path) -> bool;
+
+    /// Fetch updates from the remote.
+    fn fetch(&self, repo_path: &Path, tmp_dir: &Path);
+
+    /// Determine the default branch for a repository.
+    fn default_branch(&self, repo_path: &Path, tmp_dir: &Path) -> String;
+
+    /// Check whether the given path is a repository of this VCS type.
+    fn is_repo(&self, path: &Path) -> bool;
+
+    /// Check whether a workspace path string refers to a valid workspace.
+    fn is_valid_workspace(&self, path: &str) -> bool;
+
+    /// Run safety checks on a shell command string.
+    fn check_safety(&self, cmd: &str) -> GitResult;
+
+    /// Check whether a command should prompt the user for confirmation.
+    fn check_ask(&self, cmd: &str) -> AskResult;
+
+    /// Enforce workspace isolation for VCS commands.
+    ///
+    /// Returns `Some(denial_message)` if the command should be blocked,
+    /// `None` if it is allowed.
+    fn check_workspace_enforcement(
+        &self,
+        cmd: &str,
+        workspace_active: bool,
+        short_id: &str,
+    ) -> Option<String>;
+
+    /// Extract the repository name from a VCS operation command, if present.
+    fn extract_repo_from_op(&self, cmd: &str) -> Option<String>;
+
+    /// Check whether a command is a workspace/worktree management operation.
+    fn is_workspace_management_op(&self, cmd: &str) -> bool;
+}
+
+/// Detect the VCS kind for a directory by probing for marker directories.
+///
+/// Checks for `.jj/` and `.git/` in the given path:
+/// - Both present: [`VcsKind::JjColocated`]
+/// - Only `.jj/`: [`VcsKind::Jj`]
+/// - Only `.git/` or neither: [`VcsKind::Git`] (default)
+pub fn detect(path: &Path) -> VcsKind {
+    let has_jj = path.join(".jj").is_dir();
+    let has_git = path.join(".git").exists(); // .git can be a file (worktree) or dir
+
+    match (has_jj, has_git) {
+        (true, true) => VcsKind::JjColocated,
+        (true, false) => VcsKind::Jj,
+        _ => VcsKind::Git,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn test_dir(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("muzzle-test-vcs-{name}"));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn test_detect_git_only() {
+        let tmp = test_dir("git-only");
+        fs::create_dir(tmp.join(".git")).unwrap();
+        assert_eq!(detect(&tmp), VcsKind::Git);
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn test_detect_jj_only() {
+        let tmp = test_dir("jj-only");
+        fs::create_dir(tmp.join(".jj")).unwrap();
+        assert_eq!(detect(&tmp), VcsKind::Jj);
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn test_detect_colocated() {
+        let tmp = test_dir("colocated");
+        fs::create_dir(tmp.join(".jj")).unwrap();
+        fs::create_dir(tmp.join(".git")).unwrap();
+        assert_eq!(detect(&tmp), VcsKind::JjColocated);
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn test_detect_neither() {
+        let tmp = test_dir("neither");
+        assert_eq!(detect(&tmp), VcsKind::Git);
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn test_vcs_kind_display_roundtrip() {
+        for kind in [VcsKind::Git, VcsKind::Jj, VcsKind::JjColocated] {
+            let s = kind.to_string();
+            let parsed: VcsKind = s.parse().unwrap();
+            assert_eq!(kind, parsed, "roundtrip failed for {kind:?}");
+        }
+    }
+}

--- a/hooks/src/vcs/mod.rs
+++ b/hooks/src/vcs/mod.rs
@@ -39,7 +39,7 @@ impl std::str::FromStr for VcsKind {
 
     /// Parse a [`VcsKind`] from its string representation.
     ///
-    /// Accepts the same strings produced by [`Display`]: `"git"`, `"jj"`,
+    /// Accepts the same strings produced by [`std::fmt::Display`]: `"git"`, `"jj"`,
     /// `"jj-coloc"`. Returns `Err` with a descriptive message for unknown
     /// values.
     fn from_str(s: &str) -> Result<Self, Self::Err> {

--- a/hooks/src/worktree/mod.rs
+++ b/hooks/src/worktree/mod.rs
@@ -8,6 +8,7 @@ pub mod git;
 
 use crate::config;
 use crate::session::{SpecEntry, State};
+use crate::vcs::VcsKind;
 use std::fs;
 use std::path::Path;
 
@@ -295,6 +296,7 @@ fn create_single_worktree(
         branch: actual_branch,
         wt_path: wt_path.to_string_lossy().to_string(),
         repo_path: repo_path.to_string_lossy().to_string(),
+        vcs_kind: VcsKind::Git,
     })
 }
 
@@ -334,6 +336,7 @@ pub fn ensure_for_repo(sess: &State, repo: &str) -> Result<SpecEntry, WorktreeEr
             branch,
             wt_path: wt_path.to_string_lossy().to_string(),
             repo_path: repo_path.to_string_lossy().to_string(),
+            vcs_kind: VcsKind::Git,
         });
     }
 

--- a/hooks/tests/jj_backend.rs
+++ b/hooks/tests/jj_backend.rs
@@ -1,0 +1,346 @@
+//! Integration tests for VCS backend abstraction.
+//!
+//! Tests VCS detection, backend trait implementations (Git and Jj), safety
+//! checks, workspace management detection, and spec file roundtrips with
+//! VCS kind persistence.
+//!
+//! Run with: cargo test -p muzzle-hooks --test jj_backend
+
+use muzzle::gitcheck::GitResult;
+use muzzle::session::{self, SpecEntry};
+use muzzle::vcs::git::GitBackend;
+use muzzle::vcs::jj::JjBackend;
+use muzzle::vcs::{self, VcsBackend, VcsKind};
+use std::fs;
+use std::path::PathBuf;
+
+fn create_temp_dir(suffix: &str) -> PathBuf {
+    let dir =
+        std::env::temp_dir().join(format!("muzzle-test-jj-{}-{}", std::process::id(), suffix));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn cleanup(dir: &PathBuf) {
+    let _ = fs::remove_dir_all(dir);
+}
+
+// ---------------------------------------------------------------------------
+// VCS detection tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_vcs_detect_git_only() {
+    let dir = create_temp_dir("detect-git");
+    fs::create_dir(dir.join(".git")).unwrap();
+    assert_eq!(vcs::detect(&dir), VcsKind::Git);
+    cleanup(&dir);
+}
+
+#[test]
+fn test_vcs_detect_jj_only() {
+    let dir = create_temp_dir("detect-jj");
+    fs::create_dir(dir.join(".jj")).unwrap();
+    assert_eq!(vcs::detect(&dir), VcsKind::Jj);
+    cleanup(&dir);
+}
+
+#[test]
+fn test_vcs_detect_colocated() {
+    let dir = create_temp_dir("detect-coloc");
+    fs::create_dir(dir.join(".jj")).unwrap();
+    fs::create_dir(dir.join(".git")).unwrap();
+    assert_eq!(vcs::detect(&dir), VcsKind::JjColocated);
+    cleanup(&dir);
+}
+
+#[test]
+fn test_vcs_detect_empty() {
+    let dir = create_temp_dir("detect-empty");
+    assert_eq!(vcs::detect(&dir), VcsKind::Git); // default
+    cleanup(&dir);
+}
+
+// ---------------------------------------------------------------------------
+// GitBackend delegation tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_git_backend_kind() {
+    let backend = GitBackend;
+    assert_eq!(backend.kind(), VcsKind::Git);
+}
+
+#[test]
+fn test_git_backend_safety_delegates() {
+    let backend = GitBackend;
+    // Safe command
+    assert_eq!(backend.check_safety("git status"), GitResult::Ok);
+    // Dangerous command
+    match backend.check_safety("git push --force origin main") {
+        GitResult::Block(_) => {} // expected
+        other => panic!("expected Block, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_git_backend_is_repo() {
+    let dir = create_temp_dir("git-is-repo");
+    let backend = GitBackend;
+    assert!(!backend.is_repo(&dir)); // no .git
+    fs::create_dir(dir.join(".git")).unwrap();
+    assert!(backend.is_repo(&dir));
+    cleanup(&dir);
+}
+
+// ---------------------------------------------------------------------------
+// JjBackend safety tests (regex-only, no jj CLI needed)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_jj_backend_kind() {
+    let backend = JjBackend { colocated: false };
+    assert_eq!(backend.kind(), VcsKind::Jj);
+}
+
+#[test]
+fn test_jj_backend_kind_colocated() {
+    let backend = JjBackend { colocated: true };
+    assert_eq!(backend.kind(), VcsKind::JjColocated);
+}
+
+#[test]
+fn test_jj_backend_safety_blocks_bare_push() {
+    let backend = JjBackend { colocated: false };
+    match backend.check_safety("jj git push") {
+        GitResult::Block(reason) => assert!(reason.contains("bookmark"), "reason: {reason}"),
+        other => panic!("expected Block, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_jj_backend_safety_allows_bookmark_push() {
+    let backend = JjBackend { colocated: false };
+    assert_eq!(
+        backend.check_safety("jj git push -b my-feature"),
+        GitResult::Ok
+    );
+}
+
+#[test]
+fn test_jj_backend_safety_allows_long_bookmark_flag() {
+    let backend = JjBackend { colocated: false };
+    assert_eq!(
+        backend.check_safety("jj git push --bookmark my-feature"),
+        GitResult::Ok
+    );
+}
+
+#[test]
+fn test_jj_backend_safety_blocks_delete_main() {
+    let backend = JjBackend { colocated: false };
+    match backend.check_safety("jj bookmark delete main") {
+        GitResult::Block(reason) => assert!(reason.contains("protected"), "reason: {reason}"),
+        other => panic!("expected Block, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_jj_backend_safety_blocks_delete_master() {
+    let backend = JjBackend { colocated: false };
+    match backend.check_safety("jj bookmark delete master") {
+        GitResult::Block(_) => {} // expected
+        other => panic!("expected Block, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_jj_backend_safety_allows_delete_feature() {
+    let backend = JjBackend { colocated: false };
+    assert_eq!(
+        backend.check_safety("jj bookmark delete feature-x"),
+        GitResult::Ok
+    );
+}
+
+#[test]
+fn test_jj_backend_safety_allows_safe_commands() {
+    let backend = JjBackend { colocated: false };
+    assert_eq!(backend.check_safety("jj log"), GitResult::Ok);
+    assert_eq!(backend.check_safety("jj status"), GitResult::Ok);
+    assert_eq!(backend.check_safety("jj diff"), GitResult::Ok);
+    assert_eq!(backend.check_safety("jj new"), GitResult::Ok);
+}
+
+#[test]
+fn test_jj_backend_colocated_blocks_git_force_push() {
+    let backend = JjBackend { colocated: true };
+    match backend.check_safety("git push --force") {
+        GitResult::Block(_) => {} // expected: colocated delegates to git safety
+        other => panic!("expected Block, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_jj_backend_non_colocated_ignores_git_commands() {
+    let backend = JjBackend { colocated: false };
+    // Non-colocated jj should not check raw git commands
+    assert_eq!(backend.check_safety("git push --force"), GitResult::Ok);
+}
+
+// ---------------------------------------------------------------------------
+// JjBackend workspace management detection
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_jj_backend_workspace_management_op() {
+    let backend = JjBackend { colocated: false };
+    assert!(backend.is_workspace_management_op("jj workspace add ../foo"));
+    assert!(backend.is_workspace_management_op("jj workspace list"));
+    assert!(backend.is_workspace_management_op("jj workspace forget default"));
+    assert!(!backend.is_workspace_management_op("jj log"));
+    assert!(!backend.is_workspace_management_op("jj status"));
+}
+
+// ---------------------------------------------------------------------------
+// JjBackend is_repo
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_jj_backend_is_repo() {
+    let dir = create_temp_dir("jj-is-repo");
+    let backend = JjBackend { colocated: false };
+    assert!(!backend.is_repo(&dir)); // no .jj
+    fs::create_dir(dir.join(".jj")).unwrap();
+    assert!(backend.is_repo(&dir));
+    cleanup(&dir);
+}
+
+// ---------------------------------------------------------------------------
+// JjBackend extract_repo_from_op
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_jj_backend_extract_repo_from_op() {
+    let backend = JjBackend { colocated: false };
+    assert_eq!(
+        backend.extract_repo_from_op("jj -R /home/user/acme-api log"),
+        Some("acme-api".to_string())
+    );
+    assert_eq!(backend.extract_repo_from_op("jj log"), None);
+}
+
+// ---------------------------------------------------------------------------
+// JjBackend workspace enforcement
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_jj_backend_blocks_edit_immutable_when_active() {
+    let backend = JjBackend { colocated: false };
+    let result = backend.check_workspace_enforcement("jj edit root", true, "abc123");
+    assert!(result.is_some(), "should block jj edit root");
+    let msg = result.unwrap();
+    assert!(msg.contains("immutable"), "msg: {msg}");
+}
+
+#[test]
+fn test_jj_backend_allows_edit_immutable_when_inactive() {
+    let backend = JjBackend { colocated: false };
+    let result = backend.check_workspace_enforcement("jj edit root", false, "abc123");
+    assert!(result.is_none(), "should allow when workspace not active");
+}
+
+#[test]
+fn test_jj_backend_allows_normal_edit() {
+    let backend = JjBackend { colocated: false };
+    let result = backend.check_workspace_enforcement("jj edit abc", true, "abc123");
+    assert!(result.is_none(), "should allow edit of normal revision");
+}
+
+// ---------------------------------------------------------------------------
+// Spec file roundtrip with VCS kind
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_spec_roundtrip_with_vcs_kinds() {
+    let dir = create_temp_dir("spec-roundtrip");
+    let spec_path = dir.join("test.env");
+
+    let entries = vec![
+        SpecEntry {
+            repo: "web-app".to_string(),
+            branch: "main".to_string(),
+            wt_path: "/tmp/wt1".to_string(),
+            repo_path: "/home/user/web-app".to_string(),
+            vcs_kind: VcsKind::Git,
+        },
+        SpecEntry {
+            repo: "jj-repo".to_string(),
+            branch: String::new(),
+            wt_path: "/tmp/wt2".to_string(),
+            repo_path: "/home/user/jj-repo".to_string(),
+            vcs_kind: VcsKind::Jj,
+        },
+        SpecEntry {
+            repo: "coloc-repo".to_string(),
+            branch: "main".to_string(),
+            wt_path: "/tmp/wt3".to_string(),
+            repo_path: "/home/user/coloc-repo".to_string(),
+            vcs_kind: VcsKind::JjColocated,
+        },
+    ];
+
+    session::write_spec_file(&spec_path, &entries).unwrap();
+    let read_back = session::read_spec_file(&spec_path).unwrap();
+
+    assert_eq!(read_back.len(), 3);
+    assert_eq!(read_back[0].vcs_kind, VcsKind::Git);
+    assert_eq!(read_back[1].vcs_kind, VcsKind::Jj);
+    assert_eq!(read_back[2].vcs_kind, VcsKind::JjColocated);
+    assert_eq!(read_back[1].branch, ""); // jj has no branch
+
+    cleanup(&dir);
+}
+
+#[test]
+fn test_spec_backward_compat_4_field() {
+    let dir = create_temp_dir("spec-compat");
+    let spec_path = dir.join("legacy.env");
+
+    // Write in old 4-field format manually
+    fs::write(&spec_path, "acme-api|main|/tmp/wt|/home/user/acme-api\n").unwrap();
+
+    let entries = session::read_spec_file(&spec_path).unwrap();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].vcs_kind, VcsKind::Git); // default for legacy format
+    assert_eq!(entries[0].repo, "acme-api");
+
+    cleanup(&dir);
+}
+
+#[test]
+fn test_spec_roundtrip_preserves_all_fields() {
+    let dir = create_temp_dir("spec-fields");
+    let spec_path = dir.join("full.env");
+
+    let entries = vec![SpecEntry {
+        repo: "acme-api".to_string(),
+        branch: "feat/cool".to_string(),
+        wt_path: "/tmp/wt-acme".to_string(),
+        repo_path: "/home/user/acme-api".to_string(),
+        vcs_kind: VcsKind::Jj,
+    }];
+
+    session::write_spec_file(&spec_path, &entries).unwrap();
+    let read_back = session::read_spec_file(&spec_path).unwrap();
+
+    assert_eq!(read_back.len(), 1);
+    assert_eq!(read_back[0].repo, "acme-api");
+    assert_eq!(read_back[0].branch, "feat/cool");
+    assert_eq!(read_back[0].wt_path, "/tmp/wt-acme");
+    assert_eq!(read_back[0].repo_path, "/home/user/acme-api");
+    assert_eq!(read_back[0].vcs_kind, VcsKind::Jj);
+
+    cleanup(&dir);
+}


### PR DESCRIPTION
## Summary

- Add `VcsBackend` trait abstraction with `GitBackend` (wrapping existing code) and `JjBackend` (new jj workspace support)
- Git remains the default; jj activates via auto-detection (`.jj/` presence)
- Session `State` and `SpecEntry` carry `vcs_kind`; 5-field spec file format with backward compat for 4-field

### What changed

**New files (4):**
- `hooks/src/vcs/mod.rs` — `VcsBackend` trait, `VcsKind` enum, `detect()` function
- `hooks/src/vcs/git.rs` — `GitBackend` wrapping all existing git logic (pure delegation)
- `hooks/src/vcs/jj.rs` — `JjBackend` with workspace ops + 6 safety regex patterns
- `hooks/tests/jj_backend.rs` — 27 integration tests

**Modified files (8):** session.rs, sandbox.rs, lib.rs, gitcheck.rs, permissions.rs, ensure_worktree.rs, session_end.rs, worktree/mod.rs

### jj backend features

- `jj workspace add/forget` for session isolation
- Safety: blocks bare `jj git push`, protected bookmark deletion
- Colocated mode (`.jj/` + `.git/`): delegates git safety checks for raw git commands
- `WORKTREE_MISSING` message encodes VCS kind for `ensure-worktree` routing
- `.git` detection handles both files (worktree markers) and directories

### No new dependencies

All jj operations use `Command::new("jj")` — no new crate dependencies.

## Test plan

- [x] 39 new tests (12 unit + 27 integration), all passing
- [x] All existing 195+ unit tests still pass (6 pre-existing env failures unchanged)
- [x] `cargo check` clean
- [x] `cargo clippy -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] CI passes

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)