### PR TITLE
fix(sandbox): recognize CC-native agent worktrees as worktree paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,7 +192,7 @@ All shell scripts follow the [Google Shell Style Guide](https://google.github.io
 
 ## Testing
 
-345 tests (309 hooks unit + 5 claude_md + 17 integration + 14 proptest) plus 4 fuzz targets.
+349 tests (313 hooks unit + 5 claude_md + 17 integration + 14 proptest) plus 4 fuzz targets.
 Run with `make test` or `cargo test`.
 
 Test patterns:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,7 +192,7 @@ All shell scripts follow the [Google Shell Style Guide](https://google.github.io
 
 ## Testing
 
-349 tests (313 hooks unit + 5 claude_md + 17 integration + 14 proptest) plus 4 fuzz targets.
+351 tests (315 hooks unit + 5 claude_md + 17 integration + 14 proptest) plus 4 fuzz targets.
 Run with `make test` or `cargo test`.
 
 Test patterns:

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -81,7 +81,7 @@ sandbox config must match these:
 |---------------------------|---------------------------|---------------------------|
 | Source code (main)        | Blocked by `denyWrite`    | Blocked by WORKTREE_MISSING |
 | `.worktrees/`             | `.worktrees`              | FR-WE-3: worktree paths  |
-| `.claude/worktrees/` (CC agent worktrees) | `.claude` | FR-WE-3: worktree paths  |
+| `.claude/worktrees/<id>/` at the repo root (CC agent worktrees) | `.claude` | FR-WE-3: worktree paths  |
 | `.agents/`                | `.agents`                 | FR-WE-4: config paths    |
 | `.claude/`                | `.claude`                 | FR-WE-4: config paths    |
 | `.claude-tmp/`            | `.claude-tmp`             | FR-WE-5: state directory  |

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -81,6 +81,7 @@ sandbox config must match these:
 |---------------------------|---------------------------|---------------------------|
 | Source code (main)        | Blocked by `denyWrite`    | Blocked by WORKTREE_MISSING |
 | `.worktrees/`             | `.worktrees`              | FR-WE-3: worktree paths  |
+| `.claude/worktrees/` (CC agent worktrees) | `.claude` | FR-WE-3: worktree paths  |
 | `.agents/`                | `.agents`                 | FR-WE-4: config paths    |
 | `.claude/`                | `.claude`                 | FR-WE-4: config paths    |
 | `.claude-tmp/`            | `.claude-tmp`             | FR-WE-5: state directory  |

--- a/greptile.json
+++ b/greptile.json
@@ -72,7 +72,7 @@
       },
       {
         "scope": [],
-        "rule": "All Block() and Deny() denial messages in gitcheck.rs, sandbox.rs, and lib.rs must contain WHAT:, FIX:, and REF: tokens. Exception: the REDIRECT message for config paths in sandbox.rs (containing 'config path must persist') is exempt. Flag new denial messages missing any of the three fields."
+        "rule": "All Block() and Deny() denial messages in gitcheck.rs, sandbox.rs, and lib.rs must contain WHAT: and FIX: tokens. Do not add REF: pointers to repo-internal docs (docs/architecture.md, CLAUDE.md) — denial messages are consumed by agents running in other repos that cannot read muzzle's files. Flag new denial messages missing either field."
       },
       {
         "scope": [],

--- a/hooks/src/gitcheck.rs
+++ b/hooks/src/gitcheck.rs
@@ -147,7 +147,7 @@ static RE_PATCH: LazyLock<Regex> =
 
 /// Run all 9 git safety checks against a Bash command.
 ///
-/// Denial messages use the WHAT/FIX/REF remediation format so the agent
+/// Denial messages use the WHAT/FIX remediation format so the agent
 /// can self-repair without human intervention.
 pub fn check_git_safety(cmd: &str) -> GitResult {
     // FR-GS-1: Force push without --force-with-lease
@@ -157,8 +157,7 @@ pub fn check_git_safety(cmd: &str) -> GitResult {
     {
         return GitResult::Block(
             "WHAT: Force push without --force-with-lease. \
-             FIX: Use `git push --force-with-lease origin <branch>` instead. \
-             REF: CLAUDE.md#supply-chain-policy"
+             FIX: Use `git push --force-with-lease origin <branch>` instead."
                 .into(),
         );
     }
@@ -167,8 +166,7 @@ pub fn check_git_safety(cmd: &str) -> GitResult {
     if RE_PUSH_TO_MAIN.is_match(cmd) {
         return GitResult::Block(
             "WHAT: Direct push to main/master. \
-             FIX: Create a feature branch and open a PR instead. \
-             REF: CLAUDE.md#commit-convention"
+             FIX: Create a feature branch and open a PR instead."
                 .into(),
         );
     }
@@ -177,8 +175,7 @@ pub fn check_git_safety(cmd: &str) -> GitResult {
     if RE_REFSPEC_MAIN.is_match(cmd) {
         return GitResult::Block(
             "WHAT: Push to main/master via refspec. \
-             FIX: Create a feature branch and open a PR instead. \
-             REF: CLAUDE.md#commit-convention"
+             FIX: Create a feature branch and open a PR instead."
                 .into(),
         );
     }
@@ -187,16 +184,14 @@ pub fn check_git_safety(cmd: &str) -> GitResult {
     if RE_DELETE_MAIN.is_match(cmd) {
         return GitResult::Block(
             "WHAT: Deleting main/master branch is not allowed. \
-             FIX: Do not delete protected branches. \
-             REF: CLAUDE.md#supply-chain-policy"
+             FIX: Do not delete protected branches."
                 .into(),
         );
     }
     if RE_DELETE_REFSPEC.is_match(cmd) {
         return GitResult::Block(
             "WHAT: Deleting main/master branch via empty refspec is not allowed. \
-             FIX: Do not delete protected branches. \
-             REF: CLAUDE.md#supply-chain-policy"
+             FIX: Do not delete protected branches."
                 .into(),
         );
     }
@@ -205,8 +200,7 @@ pub fn check_git_safety(cmd: &str) -> GitResult {
     if RE_NO_VERIFY.is_match(cmd) {
         return GitResult::Block(
             "WHAT: git push --no-verify bypasses pre-push hooks. \
-             FIX: Fix the hook failures instead of skipping them. \
-             REF: CLAUDE.md#lint-suppression-policy"
+             FIX: Fix the hook failures instead of skipping them."
                 .into(),
         );
     }
@@ -215,8 +209,7 @@ pub fn check_git_safety(cmd: &str) -> GitResult {
     if RE_FOLLOW_TAGS.is_match(cmd) {
         return GitResult::Block(
             "WHAT: git push --follow-tags pushes ALL matching local tags. \
-             FIX: Push tags explicitly: `git push origin <tag>`. \
-             REF: CLAUDE.md#releases"
+             FIX: Push tags explicitly: `git push origin <tag>`."
                 .into(),
         );
     }
@@ -225,16 +218,14 @@ pub fn check_git_safety(cmd: &str) -> GitResult {
     if RE_DELETE_SEMVER_TAG.is_match(cmd) {
         return GitResult::Block(
             "WHAT: Deleting semantic version tags is not allowed. \
-             FIX: Release a new patch version instead. \
-             REF: CLAUDE.md#releases"
+             FIX: Release a new patch version instead."
                 .into(),
         );
     }
     if RE_DELETE_REMOTE_TAG.is_match(cmd) {
         return GitResult::Block(
             "WHAT: Deleting remote semantic version tags is not allowed. \
-             FIX: Release a new patch version instead. \
-             REF: CLAUDE.md#releases"
+             FIX: Release a new patch version instead."
                 .into(),
         );
     }
@@ -243,8 +234,7 @@ pub fn check_git_safety(cmd: &str) -> GitResult {
     if RE_HARD_RESET.is_match(cmd) {
         return GitResult::Block(
             "WHAT: git reset --hard origin/main|master discards all local work. \
-             FIX: Use `git stash` or `git reset --soft` instead. \
-             REF: CLAUDE.md#key-design-decisions"
+             FIX: Use `git stash` or `git reset --soft` instead."
                 .into(),
         );
     }
@@ -256,8 +246,7 @@ pub fn check_git_safety(cmd: &str) -> GitResult {
         return GitResult::Block(
             "WHAT: gh api to a commit-creating endpoint makes a server-side commit \
              that bypasses local GPG/SSH signing. \
-             FIX: Commit locally with `git commit` (signed) and push instead. \
-             REF: CLAUDE.md#supply-chain-policy"
+             FIX: Commit locally with `git commit` (signed) and push instead."
                 .into(),
         );
     }
@@ -325,8 +314,7 @@ pub fn check_worktree_enforcement(
                     }
                     return Some(format!(
                         "WHAT: Git operation targets main checkout ({repo}), not the session worktree. \
-                         FIX: Use `git -C {ws_str}/{repo}/.worktrees/{short_id}/` instead. \
-                         REF: docs/architecture.md#key-invariants"
+                         FIX: Use `git -C {ws_str}/{repo}/.worktrees/{short_id}/` instead."
                     ));
                 }
             }
@@ -349,8 +337,7 @@ pub fn check_worktree_enforcement(
                     }
                     return Some(format!(
                         "WHAT: Git operation targets main checkout ({repo}), not the session worktree. \
-                         FIX: Use `git -C {ws_str}/{repo}/.worktrees/{short_id}/` instead. \
-                         REF: docs/architecture.md#key-invariants"
+                         FIX: Use `git -C {ws_str}/{repo}/.worktrees/{short_id}/` instead."
                     ));
                 }
             }
@@ -363,8 +350,9 @@ pub fn check_worktree_enforcement(
     if let Some(subcmd) = find_bare_mutating_git(cmd) {
         return Some(format!(
             "WHAT: Bare `git {subcmd}` runs in the main checkout CWD, not the session worktree. \
-             FIX: Use `git -C <repo>/.worktrees/{short_id}/ {subcmd} ...` instead. \
-             REF: docs/architecture.md#key-invariants"
+             FIX: Use `git -C <repo>/.worktrees/{short_id}/ {subcmd} ...` instead \
+             (or `git -C <repo>/.claude/worktrees/<agent-id>/ {subcmd} ...` from an \
+             isolated agent worktree)."
         ));
     }
 
@@ -795,13 +783,17 @@ fn extract_copy_dest(cmd: &str, tool_match_end: usize) -> Option<String> {
     None
 }
 
-/// Check if a path is a main checkout (not .worktrees/ or .claude-tmp/).
+/// Check if a path is a main checkout (not a session worktree, CC-native
+/// agent worktree, or session temp).
 fn is_main_checkout_path(path: &str, workspace: &str) -> bool {
     let prefix = format!("{}/", workspace);
     if !path.starts_with(&prefix) {
         return false;
     }
-    if path.contains("/.claude-tmp/") || path.contains("/.worktrees/") {
+    if path.contains("/.claude-tmp/")
+        || path.contains("/.worktrees/")
+        || path.contains("/.claude/worktrees/")
+    {
         return false;
     }
     true
@@ -1266,6 +1258,38 @@ mod tests {
             reason.is_none(),
             "expected allow for worktree path, got: {:?}",
             reason
+        );
+    }
+
+    #[test]
+    fn test_worktree_enforcement_agent_worktree_allow() {
+        // Git ops in CC agent worktrees (<repo>/.claude/worktrees/agent-<id>)
+        // are worktree ops, not main-checkout ops.
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let fixed_ws = "/tmp/muzzle-test-ws";
+        std::env::set_var("MUZZLE_WORKSPACE", fixed_ws);
+        let cmds = [
+            format!("git -C {fixed_ws}/web-app/.claude/worktrees/agent-a1b2 commit -m msg"),
+            format!("git -C {fixed_ws}/web-app/.claude/worktrees/agent-a1b2 add ."),
+            format!("git -C {fixed_ws}/web-app/.claude/worktrees/agent-a1b2/src status"),
+        ];
+        for cmd in &cmds {
+            let reason = check_worktree_enforcement(cmd, true, "abc12345");
+            assert!(
+                reason.is_none(),
+                "expected allow for agent worktree git op {:?}, got {:?}",
+                cmd,
+                reason
+            );
+        }
+        // A repo .claude/ path that is NOT under .claude/worktrees/ is still
+        // the main checkout.
+        let cmd = format!("git -C {fixed_ws}/web-app/.claude commit -m msg");
+        let reason = check_worktree_enforcement(&cmd, true, "abc12345");
+        std::env::remove_var("MUZZLE_WORKSPACE");
+        assert!(
+            reason.is_some(),
+            "repo .claude/ dir itself must still count as main checkout"
         );
     }
 

--- a/hooks/src/gitcheck.rs
+++ b/hooks/src/gitcheck.rs
@@ -785,18 +785,25 @@ fn extract_copy_dest(cmd: &str, tool_match_end: usize) -> Option<String> {
 
 /// Check if a path is a main checkout (not a session worktree, CC-native
 /// agent worktree, or session temp).
+///
+/// Exempt layouts are anchored to the repo root so a fabricated nested
+/// directory (e.g. `<repo>/src/.claude/worktrees/`) still counts as the
+/// main checkout.
 fn is_main_checkout_path(path: &str, workspace: &str) -> bool {
     let prefix = format!("{}/", workspace);
-    if !path.starts_with(&prefix) {
+    let Some(rest) = path.strip_prefix(&prefix) else {
         return false;
-    }
-    if path.contains("/.claude-tmp/")
-        || path.contains("/.worktrees/")
-        || path.contains("/.claude/worktrees/")
-    {
-        return false;
-    }
-    true
+    };
+    let after_repo = match rest.find('/') {
+        Some(idx) => &rest[idx..],
+        None => return true, // "<ws>/<repo>" — the repo root itself
+    };
+    !(after_repo.starts_with("/.claude-tmp/")
+        || after_repo == "/.claude-tmp"
+        || after_repo.starts_with("/.worktrees/")
+        || after_repo == "/.worktrees"
+        || after_repo.starts_with("/.claude/worktrees/")
+        || after_repo == "/.claude/worktrees")
 }
 
 /// Extract the repo directory name from a workspace path.
@@ -1291,6 +1298,28 @@ mod tests {
             reason.is_some(),
             "repo .claude/ dir itself must still count as main checkout"
         );
+    }
+
+    #[test]
+    fn test_worktree_enforcement_nested_fake_worktree_denied() {
+        // Worktree exemptions are anchored to the repo root: a fabricated
+        // nested dir must not masquerade as a worktree.
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let fixed_ws = "/tmp/muzzle-test-ws";
+        std::env::set_var("MUZZLE_WORKSPACE", fixed_ws);
+        let cmds = [
+            format!("git -C {fixed_ws}/web-app/src/.claude/worktrees/agent-x commit -m msg"),
+            format!("git -C {fixed_ws}/web-app/src/.worktrees/abc12345 commit -m msg"),
+        ];
+        for cmd in &cmds {
+            let reason = check_worktree_enforcement(cmd, true, "abc12345");
+            assert!(
+                reason.is_some(),
+                "nested fake worktree path must be denied: {:?}",
+                cmd
+            );
+        }
+        std::env::remove_var("MUZZLE_WORKSPACE");
     }
 
     #[test]

--- a/hooks/src/lib.rs
+++ b/hooks/src/lib.rs
@@ -22,7 +22,7 @@ pub mod worktree;
 
 /// Format a WORKTREE_MISSING denial message for lazy worktree creation.
 ///
-/// Uses the WHAT/FIX/REF remediation format so the agent can self-repair, and
+/// Uses the WHAT/FIX remediation format so the agent can self-repair, and
 /// names common Bash bypass vectors so they aren't rationalized as a workaround.
 pub fn worktree_missing_msg(repo: &str) -> String {
     let bin = config::bin_dir().join("ensure-worktree");
@@ -31,8 +31,7 @@ pub fn worktree_missing_msg(repo: &str) -> String {
          WHAT: No worktree exists for repo '{repo}' in this session. \
          FIX: Run `{} {repo}` to create one, then retry the write. \
          DO NOT use Bash (sed -i, cp, mv, perl -i, dd, patch, ...) to bypass this — \
-         all writes to the main checkout are forbidden during worktree sessions. \
-         REF: docs/architecture.md#key-invariants",
+         all writes to the main checkout are forbidden during worktree sessions.",
         bin.display()
     )
 }

--- a/hooks/src/sandbox.rs
+++ b/hooks/src/sandbox.rs
@@ -138,13 +138,8 @@ fn check_path_dispatch(
                 }
 
                 // FR-WE-3: Allow writes to worktree paths — muzzle session
-                // worktrees and CC-native agent worktrees. Agent segment first
-                // so a nested agent worktree resolves against its own root.
-                const WORKTREE_SEGS: &[&str] = &["/.claude/worktrees/", "/.worktrees/"];
-                if let Some((seg, wt_idx)) = WORKTREE_SEGS
-                    .iter()
-                    .find_map(|seg| resolved.find(seg).map(|idx| (seg, idx)))
-                {
+                // worktrees and CC-native agent worktrees.
+                if let Some((wt_idx, seg_len)) = find_worktree_segment(&resolved, ws_str) {
                     // Gitignored writes are redirected to the main checkout so they
                     // survive worktree teardown (research notes, .agents/, tfstate,
                     // env files, etc.). Tracked files (CLAUDE.md, source, ...) stay
@@ -152,7 +147,7 @@ fn check_path_dispatch(
                     // Closes #49 (tracked CLAUDE.md no longer redirected) and #60
                     // (gitignored writes no longer silently lost).
                     // E.g. <repo>/.worktrees/<id>/.agents/foo.md → <repo>/.agents/foo.md
-                    let id_start = wt_idx + seg.len();
+                    let id_start = wt_idx + seg_len;
                     // Find the slash after the worktree ID.
                     if let Some(id_slash) = resolved[id_start..].find('/') {
                         // Redirect anything not confirmed tracked (ignored or
@@ -216,7 +211,7 @@ fn check_path_dispatch(
                 // AR-5: No legacy direct-edit mode
                 if matching_ws.is_some() && !ws_str.is_empty() {
                     // Allow writes to existing worktree paths from other sessions
-                    if resolved.contains("/.worktrees/") {
+                    if find_worktree_segment(&resolved, ws_str).is_some() {
                         return PathDecision::Allow;
                     }
                     // Allow config paths even when worktrees failed
@@ -275,6 +270,56 @@ fn check_path_dispatch(
 
     // FR-PS-7: Outside HOME — ASK
     PathDecision::Ask(format!("Write to {} — outside normal workspace", raw_path))
+}
+
+/// Worktree path segments muzzle recognizes: Claude Code native agent
+/// worktrees and muzzle session worktrees. Agent segment listed first, but
+/// [`find_worktree_segment`] picks the innermost anchored match regardless.
+const WORKTREE_SEGS: &[&str] = &["/.claude/worktrees/", "/.worktrees/"];
+
+/// Find the innermost worktree segment in `resolved` that sits at a real
+/// worktree base. Returns (segment offset, segment length).
+///
+/// Anchoring to the base prevents a fabricated nested directory
+/// (e.g. `<repo>/src/.claude/worktrees/`) from masquerading as a worktree
+/// and bypassing main-checkout isolation.
+fn find_worktree_segment(resolved: &str, ws: &str) -> Option<(usize, usize)> {
+    let mut innermost: Option<(usize, usize)> = None;
+    for seg in WORKTREE_SEGS {
+        if let Some(idx) = resolved.find(seg) {
+            if is_worktree_base(&resolved[..idx], ws)
+                && innermost.is_none_or(|(best, _)| idx > best)
+            {
+                innermost = Some((idx, seg.len()));
+            }
+        }
+    }
+    innermost
+}
+
+/// True when `prefix` (the path before a worktree segment) is a location
+/// where worktrees are actually created: a repo root (`<ws>/<repo>`) or a
+/// session worktree root (`<ws>/<repo>/.worktrees/<id>`, for agent worktrees
+/// nested inside one).
+fn is_worktree_base(prefix: &str, ws: &str) -> bool {
+    if ws.is_empty() {
+        return false;
+    }
+    let ws_prefix = format!("{}/", ws);
+    let Some(rest) = prefix.strip_prefix(&ws_prefix) else {
+        return false;
+    };
+    let mut parts = rest.split('/');
+    if parts.next().is_none_or(|repo| repo.is_empty()) {
+        return false;
+    }
+    match parts.next() {
+        None => true,
+        Some(".worktrees") => {
+            parts.next().is_some_and(|id| !id.is_empty()) && parts.next().is_none()
+        }
+        Some(_) => false,
+    }
 }
 
 /// Collapse `.` and `..` segments from a path string without touching the filesystem.
@@ -1138,6 +1183,30 @@ mod tests {
             "nested agent worktree file must be writable, got {:?}",
             result
         );
+    }
+
+    #[test]
+    fn test_nested_fake_worktree_writes_denied() {
+        // Worktree exemptions are anchored to real worktree bases: a
+        // fabricated nested dir must not masquerade as a worktree.
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let sess = sess_with_worktrees();
+        let ws = config::workspace();
+        let ws_str = ws.to_string_lossy();
+        let all_tracked = |_repo_root: &str, _path: &str| IgnoreStatus::Tracked;
+        let paths = [
+            format!("{}/web-app/src/.claude/worktrees/agent-x/evil.py", ws_str),
+            format!("{}/web-app/src/.worktrees/abc12345/evil.py", ws_str),
+        ];
+        for p in &paths {
+            let result = check_path_dispatch(p, Some(&sess), ToolContext::FileTool, &all_tracked);
+            assert!(
+                matches!(result, PathDecision::Deny(_)),
+                "nested fake worktree write must be denied: {:?} got {:?}",
+                p,
+                result
+            );
+        }
     }
 
     #[test]

--- a/hooks/src/sandbox.rs
+++ b/hooks/src/sandbox.rs
@@ -77,8 +77,7 @@ fn check_path_dispatch(
     if is_system_path(&path_str) {
         return PathDecision::Deny(format!(
             "WHAT: Write to system path {raw_path} is not allowed. \
-             FIX: Write to a project or temp directory instead. \
-             REF: docs/architecture.md#forbidden-dependencies"
+             FIX: Write to a project or temp directory instead."
         ));
     }
 
@@ -89,8 +88,7 @@ fn check_path_dispatch(
     if is_system_path(&resolved) || is_private_system_path(&resolved) {
         return PathDecision::Deny(format!(
             "WHAT: Write to system path {raw_path} is not allowed (resolves to {resolved}). \
-             FIX: Write to a project or temp directory instead. \
-             REF: docs/architecture.md#forbidden-dependencies"
+             FIX: Write to a project or temp directory instead."
         ));
     }
 
@@ -133,8 +131,20 @@ fn check_path_dispatch(
             if sess.worktree_active {
                 // Worktrees are active — strict sandbox mode
 
-                // FR-WE-3: Allow writes to worktree paths
-                if resolved.contains("/.worktrees/") {
+                // Global Claude config; before the worktree segments so
+                // ~/.claude/worktrees/ keeps its blanket allow.
+                if resolved.starts_with(&global_claude_prefix) {
+                    return PathDecision::Allow;
+                }
+
+                // FR-WE-3: Allow writes to worktree paths — muzzle session
+                // worktrees and CC-native agent worktrees. Agent segment first
+                // so a nested agent worktree resolves against its own root.
+                const WORKTREE_SEGS: &[&str] = &["/.claude/worktrees/", "/.worktrees/"];
+                if let Some((seg, wt_idx)) = WORKTREE_SEGS
+                    .iter()
+                    .find_map(|seg| resolved.find(seg).map(|idx| (seg, idx)))
+                {
                     // Gitignored writes are redirected to the main checkout so they
                     // survive worktree teardown (research notes, .agents/, tfstate,
                     // env files, etc.). Tracked files (CLAUDE.md, source, ...) stay
@@ -142,26 +152,22 @@ fn check_path_dispatch(
                     // Closes #49 (tracked CLAUDE.md no longer redirected) and #60
                     // (gitignored writes no longer silently lost).
                     // E.g. <repo>/.worktrees/<id>/.agents/foo.md → <repo>/.agents/foo.md
-                    const WORKTREES_SEG: &str = "/.worktrees/";
-                    if let Some(wt_idx) = resolved.find(WORKTREES_SEG) {
-                        let id_start = wt_idx + WORKTREES_SEG.len();
-                        // Find the slash after the worktree ID.
-                        if let Some(id_slash) = resolved[id_start..].find('/') {
-                            // Redirect anything not confirmed tracked (ignored or
-                            // unknown) to the main checkout — never risk silent
-                            // loss of a gitignored file at teardown.
-                            let wt_root = &resolved[..id_start + id_slash]; // "<repo>/.worktrees/<id>"
-                            let after_id = &resolved[id_start + id_slash..]; // "/..." after ID
-                            if ignore_status(wt_root, &resolved) != IgnoreStatus::Tracked {
-                                let repo_prefix = &resolved[..wt_idx];
-                                return PathDecision::Deny(format!(
-                                    "REDIRECT: gitignored path must persist across sessions. \
-                                     WHAT: {resolved} is gitignored and would be lost when the \
-                                     session worktree is removed. \
-                                     FIX: Write to: {repo_prefix}{after_id} (main checkout). \
-                                     REF: docs/architecture.md#key-invariants"
-                                ));
-                            }
+                    let id_start = wt_idx + seg.len();
+                    // Find the slash after the worktree ID.
+                    if let Some(id_slash) = resolved[id_start..].find('/') {
+                        // Redirect anything not confirmed tracked (ignored or
+                        // unknown) to the main checkout — never risk silent
+                        // loss of a gitignored file at teardown.
+                        let wt_root = &resolved[..id_start + id_slash]; // "<repo>/.worktrees/<id>"
+                        let after_id = &resolved[id_start + id_slash..]; // "/..." after ID
+                        if ignore_status(wt_root, &resolved) != IgnoreStatus::Tracked {
+                            let repo_prefix = &resolved[..wt_idx];
+                            return PathDecision::Deny(format!(
+                                "REDIRECT: gitignored path must persist across sessions. \
+                                 WHAT: {resolved} is gitignored and would be lost when the \
+                                 session worktree is removed. \
+                                 FIX: Write to: {repo_prefix}{after_id} (main checkout)."
+                            ));
                         }
                     }
                     return PathDecision::Allow;
@@ -174,11 +180,6 @@ fn check_path_dispatch(
 
                 // FR-WE-5: Allow writes to state directory (changelogs, specs, tmp)
                 if resolved.starts_with(&state_dir_prefix) {
-                    return PathDecision::Allow;
-                }
-
-                // Global Claude config
-                if resolved.starts_with(&global_claude_prefix) {
                     return PathDecision::Allow;
                 }
 
@@ -207,8 +208,7 @@ fn check_path_dispatch(
                         format!("{}/{}/.worktrees/{}/{}", ws_str, repo, sess.short_id, rel);
                     return PathDecision::Deny(format!(
                         "WHAT: Write targets main checkout, not the session worktree. \
-                         FIX: Use the worktree path instead: {wt_path}. \
-                         REF: docs/architecture.md#key-invariants"
+                         FIX: Use the worktree path instead: {wt_path}."
                     ));
                 }
             } else {
@@ -234,8 +234,7 @@ fn check_path_dispatch(
                     }
                     return PathDecision::Deny(
                         "WHAT: No worktree exists and repo name could not be extracted. \
-                         FIX: Ensure the write path is inside a known repo directory. \
-                         REF: docs/architecture.md#key-invariants"
+                         FIX: Ensure the write path is inside a known repo directory."
                             .into(),
                     );
                 }
@@ -1069,6 +1068,91 @@ mod tests {
             matches!(&unknown_wt, PathDecision::Deny(m) if m.contains("REDIRECT")),
             "unknown-verdict worktree path must redirect to main, got {:?}",
             unknown_wt
+        );
+    }
+
+    #[test]
+    fn test_agent_worktree_writes() {
+        // CC agent worktrees (<repo>/.claude/worktrees/agent-<id>) are
+        // worktree content (FR-WE-3), not per-repo .claude/ config: tracked
+        // files stay in place, gitignored files redirect to the main checkout.
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let sess = sess_with_worktrees();
+        let ws = config::workspace();
+        let ws_str = ws.to_string_lossy();
+
+        // Models a repo gitignoring *.local; everything else is tracked.
+        let ignore_local = |_repo_root: &str, path: &str| {
+            if path.ends_with(".local") {
+                IgnoreStatus::Ignored
+            } else {
+                IgnoreStatus::Tracked
+            }
+        };
+
+        let tracked = format!(
+            "{}/web-app/.claude/worktrees/agent-a1b2/src/main.py",
+            ws_str
+        );
+        let result =
+            check_path_dispatch(&tracked, Some(&sess), ToolContext::FileTool, &ignore_local);
+        assert!(
+            matches!(result, PathDecision::Allow),
+            "tracked file in agent worktree must be writable, got {:?}",
+            result
+        );
+
+        let gitignored = format!("{}/web-app/.claude/worktrees/agent-a1b2/dev.local", ws_str);
+        let result = check_path_dispatch(
+            &gitignored,
+            Some(&sess),
+            ToolContext::FileTool,
+            &ignore_local,
+        );
+        match &result {
+            PathDecision::Deny(msg) => {
+                assert!(msg.contains("REDIRECT"), "expected REDIRECT, got: {}", msg);
+                let target = msg.split("Write to: ").nth(1).unwrap_or("");
+                assert!(
+                    target.starts_with(&format!("{}/web-app/dev.local", ws_str)),
+                    "redirect must target the main checkout, got: {}",
+                    target
+                );
+            }
+            other => panic!(
+                "expected REDIRECT for gitignored agent-worktree file, got {:?}",
+                other
+            ),
+        }
+
+        // Agent worktree nested inside a session worktree resolves against its
+        // own (innermost) root and stays writable.
+        let nested = format!(
+            "{}/web-app/.worktrees/abc12345/.claude/worktrees/agent-a1b2/src/main.py",
+            ws_str
+        );
+        let result =
+            check_path_dispatch(&nested, Some(&sess), ToolContext::FileTool, &ignore_local);
+        assert!(
+            matches!(result, PathDecision::Allow),
+            "nested agent worktree file must be writable, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_home_claude_worktrees_allowed() {
+        // ~/.claude/worktrees/ is global Claude config space, not a repo
+        // worktree — the blanket ~/.claude/ allow applies, never the
+        // gitignore redirect.
+        let sess = sess_with_worktrees();
+        let home = config::home();
+        let p = format!("{}/.claude/worktrees/proj/wt1/notes.md", home.display());
+        let result = check_path_t(&p, Some(&sess));
+        assert!(
+            matches!(result, PathDecision::Allow),
+            "home .claude/worktrees path must be allowed, got {:?}",
+            result
         );
     }
 


### PR DESCRIPTION
## Problem

Claude Code's Agent tool (`isolation: worktree`) provisions subagent worktrees at `<repo>/.claude/worktrees/agent-<id>`. Muzzle only recognized its own `<repo>/.worktrees/<session-id>` layout:

- `gitcheck::is_main_checkout_path` classified `git -C <agent-worktree> ...` as a main-checkout op and denied it, with a FIX message pointing at the *session* worktree.
- The harness pins the subagent's Write/Edit tools to the agent worktree, so file writes and git ops were forced into two different worktrees. A subagent with Bash escapes into the session worktree (observed in the field: its branch landed there); a subagent without Bash is simply stuck.
- Write/Edit into the agent worktree only worked by accident, via the FR-WE-4 per-repo `.claude/` config exemption, which skips the gitignored-persistence redirect (#60) entirely.

## Fix

Treat `/.claude/worktrees/` like `/.worktrees/` in both layers:

- `gitcheck.rs`: agent-worktree paths are not main-checkout paths; the bare-git deny message now also names the agent-worktree `-C` form.
- `sandbox.rs`: FR-WE-3 matches both worktree layouts, agent segment first so a nested agent worktree resolves against its own (innermost) root. Tracked files stay in place; gitignored files redirect to the main checkout as for session worktrees. The blanket `~/.claude/` allow is checked first so home paths like `~/.claude/worktrees/` keep their existing behavior.

Also drops the `REF:` doc-pointer trailers from deny messages: they reference muzzle-internal files (`docs/architecture.md`, `CLAUDE.md`) that the denied agent, running in an arbitrary consumer repo, cannot read.

## Testing

`mise run ci` green. New regression tests:
- `gitcheck::test_worktree_enforcement_agent_worktree_allow` — `git -C <agent-worktree>` allowed; `git -C <repo>/.claude` still denied
- `sandbox::test_agent_worktree_writes` — tracked allowed, gitignored redirected to main checkout, nested agent-in-session worktree resolved against innermost root
- `sandbox::test_home_claude_worktrees_allowed` — `~/.claude/worktrees/` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)